### PR TITLE
Fixed some corner cases

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -52,7 +52,7 @@ clean-all: clean clean-deps clean-docs
 	$(gen_verbose) rm -rf .$(PROJECT).plt $(DEPS_DIR) logs
 
 app: ebin/$(PROJECT).app
-	$(eval MODULES := $(shell ls ebin/*.beam \
+	$(eval MODULES := $(shell find ebin -name \*.beam \
 		| sed 's/ebin\///;s/\.beam/,/' | sed '$$s/.$$//'))
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed 's/{modules, \[\]}/{modules, \[$(MODULES)\]}/' \


### PR DESCRIPTION
1. `ls ebin/*.beam` chokes when no beams present; we want empty list instead
2. missing wildcard chokes when no sources exist (e.g. in dvv/mimetypes i generate them from mime.types)
