### PR TITLE
#3 Make templates directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following files will be automatically compiled:
 | `src/$(PROJECT).app.src` | OTP application resource file |
 | `src/*.erl`              | Erlang source files           |
 | `src/*.core`             | Core Erlang source files      |
-| `templates/*.dtl`        | ErlyDTL template files        |
+| `$(TEMPLATES_DIR)/*.dtl` | ErlyDTL template files        |
 
 Only the `.app.src` file and at least one `.erl` file are required.
 
@@ -114,6 +114,9 @@ compiled before all others.
 downloaded to. It defaults to `deps`. It will be propagated into
 all the subsequent make calls, allowing all dependencies to use
 the same folder as expected.
+
+`TEMPLATES_DIR` is the path to the directory with ErlyDTL templates.
+Default value is `templates`.
 
 `CT_SUITES` is the list of common_test suites to run when you use
 the `make tests` command. If your suite module is named `ponies_SUITE`

--- a/erlang.mk
+++ b/erlang.mk
@@ -46,6 +46,8 @@ ERLC_OPTS ?= -Werror +debug_info +warn_export_all +warn_export_vars \
 COMPILE_FIRST ?=
 COMPILE_FIRST_PATHS = $(addprefix src/,$(addsuffix .erl,$(COMPILE_FIRST)))
 
+TEMPLATES_DIR ?= $(CURDIR)/templates
+
 all: deps app
 
 clean-all: clean clean-deps clean-docs
@@ -74,7 +76,7 @@ define compile_dtl =
 		init:stop()'
 endef
 
-ebin/$(PROJECT).app: src/*.erl $(wildcard src/*.core) $(wildcard templates/*.dtl)
+ebin/$(PROJECT).app: src/*.erl $(wildcard src/*.core) $(wildcard $(TEMPLATES_DIR)/*.dtl)
 	@mkdir -p ebin/
 	$(if $(strip $(filter-out %.dtl,$?)), \
 		$(call compile_erl,$(filter-out %.dtl,$?)))


### PR DESCRIPTION
Templates directory can be configured using  TEMPLATES_DIR variable. Default value: $(CURDIR)/templates
