### PR TITLE
Set ERL_LIBS=deps when compiling in test/

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -122,7 +122,7 @@ build-test-deps: $(ALL_TEST_DEPS_DIRS)
 	@for dep in $(ALL_TEST_DEPS_DIRS) ; do $(MAKE) -C $$dep; done
 
 build-tests: build-test-deps
-	$(gen_verbose) erlc -v $(ERLC_OPTS) -o test/ \
+	$(gen_verbose) ERL_LIBS=deps erlc -v $(ERLC_OPTS) -o test/ \
 		$(wildcard test/*.erl test/*/*.erl) -pa ebin/
 
 CT_RUN = ct_run \


### PR DESCRIPTION
Required for including .hrl's and using parse transforms from dependencies in test modules.
