### PR TITLE
Add '-I include/' for compile_erl to fix the error "can't find include file xxx.hrl"

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -59,7 +59,7 @@ app: ebin/$(PROJECT).app
 		> ebin/$(PROJECT).app
 
 define compile_erl
-	$(erlc_verbose) ERL_LIBS=deps erlc -v $(ERLC_OPTS) -o ebin/ -pa ebin/ \
+	$(erlc_verbose) ERL_LIBS=deps erlc -v $(ERLC_OPTS) -o ebin/ -pa ebin/ -I include/ \
 		$(COMPILE_FIRST_PATHS) $(1)
 endef
 


### PR DESCRIPTION
My project's structure is like following:

```
src/
include/
priv/
...
```

When I use `make app` to compile my project, it reports `can't find include file "xxx.hrl"`.
