### PR TITLE
Fix include error for compile_erl

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -60,7 +60,7 @@ app: ebin/$(PROJECT).app
 
 define compile_erl
 	$(erlc_verbose) ERL_LIBS=deps erlc -v $(ERLC_OPTS) -o ebin/ -pa ebin/ \
-		$(COMPILE_FIRST_PATHS) $(1)
+		-I include/ $(COMPILE_FIRST_PATHS) $(1)
 endef
 
 define compile_dtl


### PR DESCRIPTION
My project's structure is like following:

```
src/
include/
priv/
...
```

When I use make app to compile my project, it reports `can't find include file "xxx.hrl".`

Edited to below 80 columns.
