### PR TITLE
Set ERL_LIBS to $(DEPS_DIR) rather than `deps`

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -65,8 +65,8 @@ app: ebin/$(PROJECT).app
 		> ebin/$(PROJECT).app
 
 define compile_erl
-	$(erlc_verbose) ERL_LIBS=deps erlc -v $(ERLC_OPTS) -o ebin/ -pa ebin/ \
-		-I include/ $(COMPILE_FIRST_PATHS) $(1)
+	$(erlc_verbose) ERL_LIBS=$(DEPS_DIR) erlc -v $(ERLC_OPTS) -o ebin/ \
+		-pa ebin/ -I include/ $(COMPILE_FIRST_PATHS) $(1)
 endef
 
 define compile_xyrl


### PR DESCRIPTION
This solves a recursion problem when compiling deeper recursive
makefile structures. All dependencies are pulled to the top-level
dependencies directory by virtue of DEPS_DIR, but the recursive make
calls to erlc fails since the value is hard-coded.

I believe this one to be correct and just be a quick oversigt.
