### PR TITLE
When building tests, provide the correct DEPS_DIR value.

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -138,7 +138,7 @@ build-test-deps: $(ALL_TEST_DEPS_DIRS)
 	@for dep in $(ALL_TEST_DEPS_DIRS) ; do $(MAKE) -C $$dep; done
 
 build-tests: build-test-deps
-	$(gen_verbose) ERL_LIBS=deps erlc -v $(ERLC_OPTS) -o test/ \
+	$(gen_verbose) ERL_LIBS=$(DEPS_DIR) erlc -v $(ERLC_OPTS) -o test/ \
 		$(wildcard test/*.erl test/*/*.erl) -pa ebin/
 
 CT_RUN = ct_run \


### PR DESCRIPTION
Darn, nailed one, but missed the other place where deps is specified directly. I believe this is more cosmetic, but I think it needs fixing anyway.
