### PR TITLE
Allow higher level makefile to specify ERL_LIBS

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -183,8 +183,11 @@ CT_SUITES_FULL = $(addsuffix _SUITE,$(CT_SUITES))
 
 tests: ERLC_OPTS += -DTEST=1 +'{parse_transform, eunit_autoexport}'
 tests: clean deps app build-tests
-	@mkdir -p logs/
-	@$(CT_RUN) -suite $(CT_SUITES_FULL)
+	@if [ -d "test" ] ; \
+	then \
+		mkdir -p logs/ ; \
+		$(CT_RUN) -suite $(CT_SUITES_FULL) ; \
+	fi
 	$(gen_verbose) rm -f test/*.beam
 
 # Dialyzer.


### PR DESCRIPTION
Very minor tweak to allow ERL_LIBS to be set by parent makefile
