### PR TITLE
Set ERL_LIBS to $(DEPS_DIR) rather than $(DEPS)

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -62,7 +62,7 @@ ALL_TEST_DEPS_DIRS = $(addprefix $(DEPS_DIR)/,$(TEST_DEPS))
 
 # Application.
 
-ERL_LIBS ?= $(DEPS)
+ERL_LIBS ?= $(DEPS_DIR)
 export ERL_LIBS
 
 ERLC_OPTS ?= -Werror +debug_info +warn_export_all +warn_export_vars \


### PR DESCRIPTION
This fixes a problem introduced by commit 1b6aa025 such that the
dependencies were no longer being included in compilation.

Noticed due to modules in a project being unable to find behaviours
defined in dependencies.
