### PR TITLE
Add EDOC_OPTS variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ downloaded to. It defaults to `deps`. It will be propagated into
 all the subsequent make calls, allowing all dependencies to use
 the same folder as expected.
 
+`EDOC_OPTS` allows you to specify
+[options](http://www.erlang.org/doc/man/edoc.html#run-3) to pass to
+`edoc` when building the documentation. Notice: not all options are
+documented in one place; follow the links to get to the options for
+the various operations of the documentation generation.
+
 `CT_SUITES` is the list of common_test suites to run when you use
 the `make tests` command. If your suite module is named `ponies_SUITE`
 then you only need to put `ponies` in the list.

--- a/erlang.mk
+++ b/erlang.mk
@@ -189,9 +189,11 @@ clean-deps:
 
 # Documentation.
 
+EDOC_OPTS ?=
+
 docs: clean-docs
 	$(gen_verbose) erl -noshell \
-		-eval 'edoc:application($(PROJECT), ".", []), init:stop().'
+		-eval 'edoc:application($(PROJECT), ".", [$(EDOC_OPTS)]), init:stop().'
 
 clean-docs:
 	$(gen_verbose) rm -f doc/*.css doc/*.html doc/*.png doc/edoc-info


### PR DESCRIPTION
This is useful if edoc can't process the sources without using the
Erlang pre processor, for instance, or to pass other custom options
when building the documentation.
