### PR TITLE
Allow space in {modules, []} tuple

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -103,9 +103,9 @@ clean-all: clean clean-deps clean-docs
 	$(gen_verbose) rm -rf .$(PROJECT).plt $(DEPS_DIR) logs
 
 app: ebin/$(PROJECT).app
-	$(eval MODULES := $(shell find ebin -type f -name \*.beam \
+	@$(eval MODULES := $(shell find ebin -type f -name \*.beam \
 		| sed 's/ebin\///;s/\.beam/,/' | sed '$$s/.$$//'))
-	$(appsrc_verbose) cat src/$(PROJECT).app.src \
+	@$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed 's/{modules,\s*\[\]}/{modules, \[$(MODULES)\]}/' \
 		> ebin/$(PROJECT).app
 


### PR DESCRIPTION
I had `{modules, []}` in my .app.src, instead of `{modules,[]}`.

Second commit adds @ in front, to suppress spammy make output when calling sed.
