### PR TITLE
Running 'make clean-all' has errors if a dep has no Makefile

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -179,7 +179,13 @@ deps: $(ALL_DEPS_DIRS)
 	done
 
 clean-deps:
-	@for dep in $(ALL_DEPS_DIRS) ; do $(MAKE) -C $$dep clean; done
+	@for dep in $(ALL_DEPS_DIRS) ; do \
+		if [ -f $$dep/Makefile ] ; then \
+			$(MAKE) -C $$dep clean ; \
+		else \
+			echo "include $(CURDIR)/erlang.mk" | $(MAKE) -f - -C $$dep clean ; \
+		fi ; \
+	done
 
 # Documentation.
 


### PR DESCRIPTION
Create a project with a dependency that has no Makefile such as wooga/eredis.
Do 'make all' then 'make clean-all' to get an error. This patch checks for the
presence of the Makefile before attempting to run 'make clean', however, it does
not attempt run 'rebar clean' or other commands instead.
