### PR TITLE
Changed \s pattern in sed regex pattern to [[:space:]]. 

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -106,7 +106,7 @@ app: ebin/$(PROJECT).app
 	$(eval MODULES := $(shell find ebin -type f -name \*.beam \
 		| sed 's/ebin\///;s/\.beam/,/' | sed '$$s/.$$//'))
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
-		| sed 's/{modules,\s*\[\]}/{modules, \[$(MODULES)\]}/' \
+		| sed 's/{modules,[[:space:]]*\[\]}/{modules, \[$(MODULES)\]}/' \
 		> ebin/$(PROJECT).app
 
 define compile_erl


### PR DESCRIPTION
erlang.mk uses <code>\s</code> to match whitespace when matching the modules tuple in <code>src/$(PROJECT).app.src</code>. This is a GNU-specific sed extension. This breaks the build with BSD sed implementations. This change moves to <code>[[:space:]]</code> for a POSIX-compliant whitespace pattern. To test this patch, I used both sed and gsed on OS Mavericks to build farwest and it worked. I grabbed gsed from MacPorts.

This should make the sed pattern portable across GNU and BSD implementations.
