### PR TITLE
build automatically project PLT for `make dialyze` 

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -250,6 +250,7 @@ tests: clean deps app build-tests
 	$(gen_verbose) rm -f test/*.beam
 
 # Dialyzer.
+
 DIALYZER_PLT ?= $(CURDIR)/.$(PROJECT).plt
 export DIALYZER_PLT
 


### PR DESCRIPTION
the goals:
- build automatically project PLT when file is missing on `make dialyze`
- don't needs to build it explicitly (by default file is updated automatically by dialyzer when this is needed)
