### PR TITLE
Change erlydtl call to work with old and new releases

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -132,7 +132,7 @@ define compile_dtl
 		Compile = fun(F) -> \
 			Module = list_to_atom( \
 				string:to_lower(filename:basename(F, ".dtl")) ++ "_dtl"), \
-			erlydtl_compiler:compile(F, Module, [{out_dir, "ebin/"}]) \
+			erlydtl:compile(F, Module, [{out_dir, "ebin/"}]) \
 		end, \
 		_ = [Compile(F) || F <- string:tokens("$(1)", " ")], \
 		init:stop()'


### PR DESCRIPTION
Old function call was removed in https://github.com/erlydtl/erlydtl/commit/aa237513750eb926c0325d2fbb18e0b584b5d2dc. Replaced call is available in old and current versions.
