### PR TITLE
Added reminder about CT_SUITES to the make tests section of the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following targets are defined:
 | `docs`       | Generate the Edoc documentation              |
 | `clean-docs` | Clean the Edoc documentation                 |
 | `test_*`     | Run the common_test suite `*`                |
-| `tests`      | Run all the common_test suites               |
+| `tests`      | Run all the common\_test suites. Note that the CT\_SUITES variable must be defined. |
 | `build-plt`  | Generate the PLT needed by Dialyzer          |
 | `dialyze`    | Run Dialyzer on the application              |
 | `pkg-list`   | List packages in the index                   |


### PR DESCRIPTION
It seems to me that CT_SUITES must be defined in order for `make tests` to work correctly. This wasn't specified in the README.
