### PR TITLE
Support building dependencies with erlang.mk in a different directory

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -179,6 +179,8 @@ $(DEPS_DIR)/$(1):
 	$(call get_dep,$(1))
 endef
 
+ERLANG_MK = $(abspath $(lastword $(MAKEFILE_LIST)))
+
 $(foreach dep,$(DEPS),$(eval $(call dep_target,$(dep))))
 
 deps: $(ALL_DEPS_DIRS)
@@ -186,7 +188,7 @@ deps: $(ALL_DEPS_DIRS)
 		if [ -f $$dep/Makefile ] ; then \
 			$(MAKE) -C $$dep ; \
 		else \
-			echo "include $(CURDIR)/erlang.mk" | $(MAKE) -f - -C $$dep ; \
+			echo "include $(ERLANG_MK)" | $(MAKE) -f - -C $$dep ; \
 		fi ; \
 	done
 
@@ -195,7 +197,7 @@ clean-deps:
 		if [ -f $$dep/Makefile ] ; then \
 			$(MAKE) -C $$dep clean ; \
 		else \
-			echo "include $(CURDIR)/erlang.mk" | $(MAKE) -f - -C $$dep clean ; \
+			echo "include $(ERLANG_MK)" | $(MAKE) -f - -C $$dep clean ; \
 		fi ; \
 	done
 


### PR DESCRIPTION
If a dependency has no makefile, it is built by including the project's own erlang.mk .This is done by `$(CURDIR)/erlang.mk`, which assumes that erlang.mk is in the same directory as the project's Makefile. This doesn't work if a project has make targets in different directories that share a single erlang.mk in the file tree, e.g. project/apps/app1/Makefile includes ../../erlang.mk.
This can be fixed by using MAKEFILE_LIST.
