### PR TITLE
Change GitHub raw file URL

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -25,7 +25,7 @@ export ERL_LIBS
 PKG_FILE ?= $(CURDIR)/.erlang.mk.packages.v1
 export PKG_FILE
 
-PKG_FILE_URL ?= https://raw.github.com/extend/erlang.mk/master/packages.v1.tsv
+PKG_FILE_URL ?= https://raw.githubusercontent.com/extend/erlang.mk/master/packages.v1.tsv
 
 # Core targets.
 

--- a/erlang.mk
+++ b/erlang.mk
@@ -21,7 +21,7 @@ PROJECT ?= $(notdir $(CURDIR))
 PKG_FILE ?= $(CURDIR)/.erlang.mk.packages.v1
 export PKG_FILE
 
-PKG_FILE_URL ?= https://raw.github.com/extend/erlang.mk/master/packages.v1.tsv
+PKG_FILE_URL ?= https://raw.githubusercontent.com/extend/erlang.mk/master/packages.v1.tsv
 
 define get_pkg_file
 	wget --no-check-certificate -O $(PKG_FILE) $(PKG_FILE_URL) || rm $(PKG_FILE)


### PR DESCRIPTION
GitHub issues a 301 Moved Permanently response on all calls to
`https://raw.github.com`, which redirects to
`https://raw.githubusercontent.com`.
