### PR TITLE
move CT_OPTS so that -erl_args works as expected when running tests

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -230,8 +230,7 @@ CT_RUN = ct_run \
 	-noshell \
 	-pa $(realpath ebin) $(DEPS_DIR)/*/ebin \
 	-dir test \
-	-logdir logs \
-	$(CT_OPTS)
+	-logdir logs
 
 CT_SUITES ?=
 
@@ -241,7 +240,7 @@ test_$(1): clean deps app build-tests
 	@if [ -d "test" ] ; \
 	then \
 		mkdir -p logs/ ; \
-		$(CT_RUN) -suite $(addsuffix _SUITE,$(1)) ; \
+		$(CT_RUN) -suite $(addsuffix _SUITE,$(1)) $(CT_OPTS) ; \
 	fi
 	$(gen_verbose) rm -f test/*.beam
 endef
@@ -253,7 +252,7 @@ tests: clean deps app build-tests
 	@if [ -d "test" ] ; \
 	then \
 		mkdir -p logs/ ; \
-		$(CT_RUN) -suite $(addsuffix _SUITE,$(CT_SUITES)) ; \
+		$(CT_RUN) -suite $(addsuffix _SUITE,$(CT_SUITES)) $(CT_OPTS) ; \
 	fi
 	$(gen_verbose) rm -f test/*.beam
 

--- a/plugins/ct.mk
+++ b/plugins/ct.mk
@@ -33,8 +33,7 @@ CT_RUN = ct_run \
 	-noshell \
 	-pa $(realpath ebin) $(DEPS_DIR)/*/ebin \
 	-dir test \
-	-logdir logs \
-	$(CT_OPTS)
+	-logdir logs
 
 $(foreach dep,$(TEST_DEPS),$(eval $(call dep_target,$(dep))))
 
@@ -50,7 +49,7 @@ tests-ct: clean deps app build-ct-suites
 	@if [ -d "test" ] ; \
 	then \
 		mkdir -p logs/ ; \
-		$(CT_RUN) -suite $(addsuffix _SUITE,$(CT_SUITES)) ; \
+		$(CT_RUN) -suite $(addsuffix _SUITE,$(CT_SUITES)) $(CT_OPTS) ; \
 	fi
 	$(gen_verbose) rm -f test/*.beam
 
@@ -60,7 +59,7 @@ ct-$(1): clean deps app build-tests
 	@if [ -d "test" ] ; \
 	then \
 		mkdir -p logs/ ; \
-		$(CT_RUN) -suite $(addsuffix _SUITE,$(1)) ; \
+		$(CT_RUN) -suite $(addsuffix _SUITE,$(1)) $(CT_OPTS) ; \
 	fi
 	$(gen_verbose) rm -f test/*.beam
 endef


### PR DESCRIPTION
I noticed when trying to run tests with the -erl_args flag the -suite flag was ignored since -erl_args delimits ct flags from erl flags. So although not as clean CT_OPTS needs to be at the end of the ct command for -erl_args to behave as expected.
