### PR TITLE
Fix setting `RELX_OUTPUT_DIR` from `RELX_OPTS` implicitly

### DIFF
--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -16,8 +16,8 @@ RELX_URL ?= https://github.com/erlware/relx/releases/download/v1.0.2/relx
 RELX_OPTS ?=
 RELX_OUTPUT_DIR ?= _rel
 
-ifneq ($(firstword $(subst -o,,$(RELX_OPTS))),)
-	RELX_OUTPUT_DIR = $(firstword $(subst -o,,$(RELX_OPTS)))
+ifeq ($(firstword $(RELX_OPTS)),-o)
+	RELX_OUTPUT_DIR = $(word 2,$(RELX_OPTS))
 endif
 
 # Core targets.


### PR DESCRIPTION
Example: setting `RELX_OPTS = --dev-mode` causes erlang.mk to try and use `--dev-mode` as the relx output directory.

This fix is imperfect: it only works if `-o $DIR` are the first args in `RELX_OPTS`. It does not implicitly set the `RELX_OUTPUT_DIR` when there is an arg other than `-o`, e.g. `--dev-mode`, leading `RELX_OPTS`. Not sure how to pick out the argument following `-o` in make.

Also, I rebuilt `erlang.mk`, but there were differences outside of my changes so I decided to leave it out of the commit. Should the updated `erlang.mk` file be part of this commit?
