### PR TITLE
Allow $DIALYZER_OPTS to add more source directories

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -269,7 +269,7 @@ build-plt: deps app
 	@dialyzer --build_plt --apps erts kernel stdlib $(PLT_APPS) $(ALL_DEPS_DIRS)
 
 dialyze:
-	@dialyzer --src src --no_native $(DIALYZER_OPTS)
+	@dialyzer --no_native --src src $(DIALYZER_OPTS)
 
 # Packages.
 

--- a/plugins/dialyzer.mk
+++ b/plugins/dialyzer.mk
@@ -31,4 +31,4 @@ distclean-plt:
 	$(gen_verbose) rm -f $(DIALYZER_PLT)
 
 dialyze:
-	@dialyzer --src src --no_native $(DIALYZER_OPTS)
+	@dialyzer --no_native --src src $(DIALYZER_OPTS)


### PR DESCRIPTION
The current ordering of args in the dialyzer command don't allow additional source directories to be specified. Putting --no_native first allows the beginning of the $DIALYZER_OPTS to specify additional directories of files to be analyzed.
