### PR TITLE
Declare CT_SUITES only when running tests target

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -232,7 +232,11 @@ CT_RUN = ct_run \
 	-dir test \
 	-logdir logs
 
-CT_SUITES ?= $(sort $(subst _SUITE.erl,,$(shell find test -type f -name \*_SUITE.erl -exec basename {} \;)))
+ifneq ($(wildcard test/),)
+	CT_SUITES ?= $(sort $(subst _SUITE.erl,,$(shell find test -type f -name \*_SUITE.erl -exec basename {} \;)))
+else
+	CT_SUITES ?=
+endif
 
 define test_target
 test_$(1): ERLC_OPTS = $(TEST_ERLC_OPTS)

--- a/plugins/ct.mk
+++ b/plugins/ct.mk
@@ -6,7 +6,11 @@
 # Configuration.
 
 CT_OPTS ?=
-CT_SUITES ?= $(sort $(subst _SUITE.erl,,$(shell find test -type f -name \*_SUITE.erl -exec basename {} \;)))
+ifneq ($(wildcard test/),)
+	CT_SUITES ?= $(sort $(subst _SUITE.erl,,$(shell find test -type f -name \*_SUITE.erl -exec basename {} \;)))
+else
+	CT_SUITES ?=
+endif
 
 TEST_ERLC_OPTS ?= +debug_info +warn_export_vars +warn_shadow_vars +warn_obsolete_guard
 TEST_ERLC_OPTS += -DTEST=1 -DEXTRA=1 +'{parse_transform, eunit_autoexport}'


### PR DESCRIPTION
I moved the CT_SUITES declaration to inside of the tests target and only run it if we have a test directory. It will still produce the missing test warning if the directory does not exists but I think that is a good behaviour.
