### PR TITLE
Fixed output of help command

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -252,7 +252,7 @@ help::
 		"  bootstrap-lib      Generate a skeleton of an OTP library" \
 		"  bootstrap-rel      Generate the files needed to build a release" \
 		"  new t=TPL n=NAME   Generate a module NAME based on the template TPL" \
-		"  bootstrap-lib      List available templates"
+		"  list-templates     List available templates"
 
 # Bootstrap templates.
 

--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -12,7 +12,7 @@ help::
 		"  bootstrap-lib      Generate a skeleton of an OTP library" \
 		"  bootstrap-rel      Generate the files needed to build a release" \
 		"  new t=TPL n=NAME   Generate a module NAME based on the template TPL" \
-		"  bootstrap-lib      List available templates"
+		"  list-templates     List available templates"
 
 # Bootstrap templates.
 


### PR DESCRIPTION
list-templates was replaced by bootstrap-lib in the output of the help command.
