### PR TITLE
Don't distclean before building release

### DIFF
--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -22,7 +22,7 @@ endif
 
 # Core targets.
 
-rel:: distclean-rel $(RELX)
+rel:: $(RELX)
 	@$(RELX) -c $(RELX_CONFIG) $(RELX_OPTS)
 
 distclean:: distclean-rel


### PR DESCRIPTION
It removes the relx binary on each release build forcing it to be redownloaded
on each run.
