### PR TITLE
Autobuild plt if it is missing

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -618,13 +618,19 @@ help::
 
 # Plugin-specific targets.
 
-plt: deps app
+$(DIALYZER_PLT): deps app
 	@dialyzer --build_plt --apps erts kernel stdlib $(PLT_APPS) $(ALL_DEPS_DIRS)
+
+plt: $(DIALYZER_PLT)
 
 distclean-plt:
 	$(gen_verbose) rm -f $(DIALYZER_PLT)
 
+ifneq ($(wildcard $(DIALYZER_PLT)),)
 dialyze:
+else
+dialyze: $(DIALYZER_PLT)
+endif
 	@dialyzer --no_native --src -r src $(DIALYZER_OPTS)
 
 # Copyright (c) 2013-2014, Loïc Hoguin <essen@ninenines.eu>

--- a/plugins/dialyzer.mk
+++ b/plugins/dialyzer.mk
@@ -24,11 +24,17 @@ help::
 
 # Plugin-specific targets.
 
-plt: deps app
+$(DIALYZER_PLT): deps app
 	@dialyzer --build_plt --apps erts kernel stdlib $(PLT_APPS) $(ALL_DEPS_DIRS)
+
+plt: $(DIALYZER_PLT)
 
 distclean-plt:
 	$(gen_verbose) rm -f $(DIALYZER_PLT)
 
+ifneq ($(wildcard $(DIALYZER_PLT)),)
 dialyze:
+else
+dialyze: $(DIALYZER_PLT)
+endif
 	@dialyzer --no_native --src -r src $(DIALYZER_OPTS)


### PR DESCRIPTION
No need to call make plt before make dialyze

Heavily based on pull request #37 which it closes.
