### PR TITLE
Add warning if empty modules entry in .app.src

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -700,6 +700,10 @@ endif
 # Core targets.
 
 rel:: distclean-rel $(RELX)
+	@if [ -z "$$(grep -E '{modules,[[:space:]]*\[\]}' src/$(PROJECT).app.src)" ]; then \
+		echo "WARNING: empty modules entry not found in src/$(PROJECT).app.src. This may result in relx release failure." \
+		"See README for details."; \
+	fi
 	@$(RELX) -c $(RELX_CONFIG) $(RELX_OPTS)
 
 distclean:: distclean-rel

--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -23,6 +23,10 @@ endif
 # Core targets.
 
 rel:: distclean-rel $(RELX)
+	@if [ -z "$$(grep -E '{modules,[[:space:]]*\[\]}' src/$(PROJECT).app.src)" ]; then \
+		echo "WARNING: empty modules entry not found in src/$(PROJECT).app.src. This may result in relx release failure." \
+		"See README for details."; \
+	fi
 	@$(RELX) -c $(RELX_CONFIG) $(RELX_OPTS)
 
 distclean:: distclean-rel


### PR DESCRIPTION
An empty list is required for the modules tuple, as in
{modules, []}
so a sed call could populate the list. This is mentioned in README, but
can be overlooked.

As discussed in https://github.com/ninenines/erlang.mk/pull/85, this isn't immediately fixable. Therefore, if the empty tuple is not present, relx can fail on missing dependency
errors. Therefore, output a warning if the empty tuple isn't found, to
help the user diagnose the problem.
