### PR TITLE
Fail if missing empty modules entry in .app.src

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -26,6 +26,10 @@ xyrl_verbose = $(xyrl_verbose_$(V))
 app:: ebin/$(PROJECT).app
 	$(eval MODULES := $(shell find ebin -type f -name \*.beam \
 		| sed "s/ebin\//'/;s/\.beam/',/" | sed '$$s/.$$//'))
+	@if [ -z "$$(grep -E '^[^%]*{modules,[[:space:]]*\[\]}' src/$(PROJECT).app.src)" ]; then \
+		echo "Empty modules entry not found in $(PROJECT).app.src. Please consult the erlang.mk README for instructions." >&2; \
+		exit 1; \
+	fi
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed "s/{modules,[[:space:]]*\[\]}/{modules, \[$(MODULES)\]}/" \
 		> ebin/$(PROJECT).app

--- a/erlang.mk
+++ b/erlang.mk
@@ -204,6 +204,10 @@ xyrl_verbose = $(xyrl_verbose_$(V))
 app:: ebin/$(PROJECT).app
 	$(eval MODULES := $(shell find ebin -type f -name \*.beam \
 		| sed "s/ebin\//'/;s/\.beam/',/" | sed '$$s/.$$//'))
+	@if [ -z "$$(grep -E '^[^%]*{modules,[[:space:]]*\[\]}' src/$(PROJECT).app.src)" ]; then \
+		echo "Empty modules entry not found in $(PROJECT).app.src. Please consult the erlang.mk README for instructions." >&2; \
+		exit 1; \
+	fi
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed "s/{modules,[[:space:]]*\[\]}/{modules, \[$(MODULES)\]}/" \
 		> ebin/$(PROJECT).app


### PR DESCRIPTION
An empty list is required for the modules tuple, as in
{modules, []}
so a sed call could populate the list. This is mentioned in README, but
can be overlooked.

If the empty tuple is not present, relx will fail on missing dependency
errors. Therefore, fail make if the empty tuple isn't found, to
help the user diagnose the problem.
