### PR TITLE
Add error message before failing due to invalid dependency

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -47,6 +47,7 @@ define dep_fetch
 		git clone -n -- $$$$REPO $(DEPS_DIR)/$(1); \
 		cd $(DEPS_DIR)/$(1) && git checkout -q $$$$COMMIT; \
 	else \
+		echo "Unknown or invalid dependency: $(1). Please consult the erlang.mk README for instructions." >&2; \
 		exit 78; \
 	fi
 endef

--- a/erlang.mk
+++ b/erlang.mk
@@ -115,6 +115,7 @@ define dep_fetch
 		git clone -n -- $$$$REPO $(DEPS_DIR)/$(1); \
 		cd $(DEPS_DIR)/$(1) && git checkout -q $$$$COMMIT; \
 	else \
+		echo "Unknown or invalid dependency: $(1). Please consult the erlang.mk README for instructions." >&2; \
 		exit 78; \
 	fi
 endef


### PR DESCRIPTION
If a dependency specified in DEPS is unknown or invalid (its VS
is not "git"), erlang.mk will fail. Now, add a human-readable
error message to help the user understand what the problem is.
