### PR TITLE
Add tinymt-erlang to the package index

### DIFF
--- a/packages.v1.tsv
+++ b/packages.v1.tsv
@@ -15,3 +15,4 @@ proper	https://github.com/manopapad/proper	http://proper.softlab.ntua.gr	PropEr:
 ranch	https://github.com/ninenines/ranch	http://ninenines.eu	Socket acceptor pool for TCP protocols.
 resource_discovery	https://github.com/erlware/resource_discovery	http://erlware.org/	An application used to dynamically discover resources present in an Erlang node cluster.
 sheriff	https://github.com/extend/sheriff	http://ninenines.eu	Parse transform for type based validation.
+tinymt-erlang	https://github.com/jj1bdx/tinymt-erlang	https://github.com/jj1bdx/tinymt-erlang	TinyMT pseudo random number generator for Erlang.

--- a/packages.v1.txt
+++ b/packages.v1.txt
@@ -15,3 +15,4 @@ proper	https://github.com/manopapad/proper	http://proper.softlab.ntua.gr	PropEr:
 ranch	https://github.com/ninenines/ranch	http://ninenines.eu	Socket acceptor pool for TCP protocols.
 resource_discovery	https://github.com/erlware/resource_discovery	http://erlware.org/	An application used to dynamically discover resources present in an Erlang node cluster.
 sheriff	https://github.com/extend/sheriff	http://ninenines.eu	Parse transform for type based validation.
+tinymt-erlang	https://github.com/jj1bdx/tinymt-erlang	https://github.com/jj1bdx/tinymt-erlang	TinyMT pseudo random number generator for Erlang.

--- a/packages.v2.tsv
+++ b/packages.v2.tsv
@@ -15,3 +15,4 @@ proper	git	https://github.com/manopapad/proper	master	http://proper.softlab.ntua
 ranch	git	https://github.com/ninenines/ranch	1.0.0	http://ninenines.eu	Socket acceptor pool for TCP protocols.
 resource_discovery	git	https://github.com/erlware/resource_discovery	master	http://erlware.org/	An application used to dynamically discover resources present in an Erlang node cluster.
 sheriff	git	https://github.com/extend/sheriff	master	http://ninenines.eu	Parse transform for type based validation.
+tinymt-erlang	git	https://github.com/jj1bdx/tinymt-erlang	master	https://github.com/jj1bdx/tinymt-erlang	TinyMT pseudo random number generator for Erlang.


### PR DESCRIPTION
Add tinymt-erlang to the package index
(Update: branch rebased to ninenines/erlang.mk to remove unnecessary commits)
