### PR TITLE
erlc-include: echo -n does not work under OS X

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -64,7 +64,7 @@ clean:: clean-app
 
 erlc-include:
 	-@if [ -d ebin/ ]; then \
-		find include/ src/ -type f -name \*.hrl -newer ebin -exec touch $(shell find src/ -type f -name "*.erl") \; 2>/dev/null || echo -n; \
+		find include/ src/ -type f -name \*.hrl -newer ebin -exec touch $(shell find src/ -type f -name "*.erl") \; 2>/dev/null || printf ''; \
 	fi
 
 clean-app:

--- a/erlang.mk
+++ b/erlang.mk
@@ -242,7 +242,7 @@ clean:: clean-app
 
 erlc-include:
 	-@if [ -d ebin/ ]; then \
-		find include/ src/ -type f -name \*.hrl -newer ebin -exec touch $(shell find src/ -type f -name "*.erl") \; 2>/dev/null || echo -n; \
+		find include/ src/ -type f -name \*.hrl -newer ebin -exec touch $(shell find src/ -type f -name "*.erl") \; 2>/dev/null || printf ''; \
 	fi
 
 clean-app:


### PR DESCRIPTION
When running `make` using erlang.mk 1.1.0, the output looks something like this:

``` bash
-n
APP    noesis.app.src
```

The cause of this is the `echo -n` in the `erlc-include` target.

Apple mentions this in the [man pages](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/echo.1.html). Changing the line to `/bin/echo -n` works, but I'm not sure if that's a good idea.
