### PR TITLE
fix typo in ifneq

### DIFF
--- a/plugins/c_src.mk
+++ b/plugins/c_src.mk
@@ -48,7 +48,7 @@ $(C_SRC_ENV):
 -include $(C_SRC_ENV)
 
 else
-ifneq ($(wildcard $(C_SRC_DIR),))
+ifneq ($(wildcard $(C_SRC_DIR)),)
 
 app::
 	$(MAKE) -C $(C_SRC_DIR)


### PR DESCRIPTION
c_src plugin with a custom Makefile was failing due to an "invalid syntax" or something to that effect.  This patch fixes that.
