### PR TITLE
Fix for the cowboy_rest template

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -421,7 +421,7 @@ tpl_cowboy_rest = "-module($(n))." \
 	"	{upgrade, protocol, cowboy_rest}." \
 	"" \
 	"content_types_provided(Req, State) ->" \
-	"	{[{{<<\"text\">>, <<\"html\">>, '_'}, get_html}], Req, State}." \
+	"	{[{{<<\"text\">>, <<\"html\">>, '*'}, get_html}], Req, State}." \
 	"" \
 	"get_html(Req, State) ->" \
 	"	{<<\"<html><body>This is REST!</body></html>\">>, Req, State}."

--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -162,7 +162,7 @@ tpl_cowboy_rest = "-module($(n))." \
 	"	{upgrade, protocol, cowboy_rest}." \
 	"" \
 	"content_types_provided(Req, State) ->" \
-	"	{[{{<<\"text\">>, <<\"html\">>, '_'}, get_html}], Req, State}." \
+	"	{[{{<<\"text\">>, <<\"html\">>, '*'}, get_html}], Req, State}." \
 	"" \
 	"get_html(Req, State) ->" \
 	"	{<<\"<html><body>This is REST!</body></html>\">>, Req, State}."


### PR DESCRIPTION
The default cowboy_rest template give an error when used as it is.

```
Error in process <0.156.0> with exit value: {function_clause,[{lists,sort,['_'],[{file,"lists.erl"},{line,478}]},{cowboy_rest,match_media_type_params,5,[{file,"src/cowboy_rest.erl"},{line,315}]},{cowboy_protocol,execute,4,[{file,"src/cowboy_protocol.erl"},{line,435}]}]}
```
