### PR TITLE
Fix esx* package names to exs*

### DIFF
--- a/packages.v1.tsv
+++ b/packages.v1.tsv
@@ -15,9 +15,9 @@ eredis	https://github.com/wooga/eredis	https://github.com/wooga/eredis	Non-block
 erldb	https://github.com/erldb/erldb.git	http://erldb.org	ORM (Object-relational mapping) application implemented in Erlang
 erlydtl	https://github.com/erlydtl/erlydtl	https://github.com/erlydtl/erlydtl	Django Template Language for Erlang.
 erwa	https://github.com/bwegh/erwa	https://github.com/bwegh/erwa	A WAMP router and client written in Erlang.
-esx1024	https://github.com/jj1bdx/esx1024	https://github.com/jj1bdx/esx1024	Xorshift1024star pseudo random number generator for Erlang.
-esx64	https://github.com/jj1bdx/esx64	https://github.com/jj1bdx/esx64	Xorshift64star pseudo random number generator for Erlang.
-esxplus	https://github.com/jj1bdx/esxplus	https://github.com/jj1bdx/esxplus	Xorshift128plus pseudo random number generator for Erlang.
+exs1024	https://github.com/jj1bdx/exs1024	https://github.com/jj1bdx/exs1024	Xorshift1024star pseudo random number generator for Erlang.
+exs64	https://github.com/jj1bdx/exs64	https://github.com/jj1bdx/exs64	Xorshift64star pseudo random number generator for Erlang.
+exsplus	https://github.com/jj1bdx/exsplus	https://github.com/jj1bdx/exsplus	Xorshift128plus pseudo random number generator for Erlang.
 gun	https://github.com/extend/gun	http//ninenines.eu	Asynchronous SPDY, HTTP and Websocket client written in Erlang.
 ibrowse	https://github.com/cmullaparthi/ibrowse	https://github.com/cmullaparthi/ibrowse	Erlang HTTP client
 itweet	https://github.com/inaka/itweet.git	http://inaka.github.com/itweet/	Twitter Stream API on ibrowse

--- a/packages.v1.txt
+++ b/packages.v1.txt
@@ -15,9 +15,9 @@ eredis	https://github.com/wooga/eredis	https://github.com/wooga/eredis	Non-block
 erldb	https://github.com/erldb/erldb.git	http://erldb.org	ORM (Object-relational mapping) application implemented in Erlang
 erlydtl	https://github.com/erlydtl/erlydtl	https://github.com/erlydtl/erlydtl	Django Template Language for Erlang.
 erwa	https://github.com/bwegh/erwa	https://github.com/bwegh/erwa	A WAMP router and client written in Erlang.
-esx1024	https://github.com/jj1bdx/esx1024	https://github.com/jj1bdx/esx1024	Xorshift1024star pseudo random number generator for Erlang.
-esx64	https://github.com/jj1bdx/esx64	https://github.com/jj1bdx/esx64	Xorshift64star pseudo random number generator for Erlang.
-esxplus	https://github.com/jj1bdx/esxplus	https://github.com/jj1bdx/esxplus	Xorshift128plus pseudo random number generator for Erlang.
+exs1024	https://github.com/jj1bdx/exs1024	https://github.com/jj1bdx/exs1024	Xorshift1024star pseudo random number generator for Erlang.
+exs64	https://github.com/jj1bdx/exs64	https://github.com/jj1bdx/exs64	Xorshift64star pseudo random number generator for Erlang.
+exsplus	https://github.com/jj1bdx/exsplus	https://github.com/jj1bdx/exsplus	Xorshift128plus pseudo random number generator for Erlang.
 gun	https://github.com/extend/gun	http//ninenines.eu	Asynchronous SPDY, HTTP and Websocket client written in Erlang.
 ibrowse	https://github.com/cmullaparthi/ibrowse	https://github.com/cmullaparthi/ibrowse	Erlang HTTP client
 itweet	https://github.com/inaka/itweet.git	http://inaka.github.com/itweet/	Twitter Stream API on ibrowse

--- a/packages.v2.tsv
+++ b/packages.v2.tsv
@@ -15,9 +15,9 @@ eredis	git	https://github.com/wooga/eredis	master	https://github.com/wooga/eredi
 erldb	git	https://github.com/erldb/erldb.git	master	http://erldb.org	ORM (Object-relational mapping) application implemented in Erlang
 erlydtl	git	https://github.com/erlydtl/erlydtl	master	https://github.com/erlydtl/erlydtl	Django Template Language for Erlang.
 erwa	git	https://github.com/bwegh/erwa	master	https://github.com/bwegh/erwa	A WAMP router and client written in Erlang.
-esx1024	git	https://github.com/jj1bdx/esx1024	master	https://github.com/jj1bdx/esx1024	Xorshift1024star pseudo random number generator for Erlang.
-esx64	git	https://github.com/jj1bdx/esx64	master	https://github.com/jj1bdx/esx64	Xorshift64star pseudo random number generator for Erlang.
-esxplus	git	https://github.com/jj1bdx/esxplus	master	https://github.com/jj1bdx/esxplus	Xorshift128plus pseudo random number generator for Erlang.
+exs1024	git	https://github.com/jj1bdx/exs1024	master	https://github.com/jj1bdx/exs1024	Xorshift1024star pseudo random number generator for Erlang.
+exs64	git	https://github.com/jj1bdx/exs64	master	https://github.com/jj1bdx/exs64	Xorshift64star pseudo random number generator for Erlang.
+exsplus	git	https://github.com/jj1bdx/exsplus	master	https://github.com/jj1bdx/exsplus	Xorshift128plus pseudo random number generator for Erlang.
 gun	git	https://github.com/extend/gun	master	http//ninenines.eu	Asynchronous SPDY, HTTP and Websocket client written in Erlang.
 ibrowse	git	https://github.com/cmullaparthi/ibrowse	v4.1.1	https://github.com/cmullaparthi/ibrowse	Erlang HTTP client
 itweet	git	https://github.com/inaka/itweet.git	3.0	http://inaka.github.com/itweet/	Twitter Stream API on ibrowse


### PR DESCRIPTION
- esx64, esxplus, esx1024 -> exs64, exsplus, exs1024
- See https://github.com/ninenines/erlang.mk/pull/129#issuecomment-56919453
  Thx @ddosia
