### PR TITLE
`distclean-pkg` sub-target only removes PKG_FILE2 when file is default.

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -178,7 +178,7 @@ pkg-search:
 endif
 
 distclean-pkg:
-	@if [ $(PKG_FILE2) == $(CURDIR)/$(DEFAULT_PKG_FILE) ]; then $(gen_verbose) rm -f $(PKG_FILE2); fi
+	@if [ $(PKG_FILE2) = $(CURDIR)/$(DEFAULT_PKG_FILE) ]; then $(gen_verbose) rm -f $(PKG_FILE2); fi
 
 help::
 	@printf "%s\n" "" \


### PR DESCRIPTION
erlang.mk packaging instructions encourage user to define a custom package file as follows,

"You can use a custom package file, in which case you will probably want to set the PKG_FILE2 variable to its location."

However, `distclean-pkg` sub-target removes whatever file is defined under PKG_FILE2. If it's a user custom package file, we don't want erlang.mk to remove it.
