### PR TITLE
erlc: update {id, git} in .app.src with git describe output

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ variable. It takes the arguments that will then be passed to
 You can specify a list of modules to be compiled first using
 the `COMPILE_FIRST` variable.
 
+If `{id, "git"},` is found in your project's `.app.src`, the
+extended output of `git describe ...` will replace it. This
+can be retrieved at runtime via `application:get_key/2`.
+
 Bootstrap plugin
 ----------------
 

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -30,8 +30,10 @@ app:: erlc-include ebin/$(PROJECT).app
 		echo "Empty modules entry not found in $(PROJECT).app.src. Please consult the erlang.mk README for instructions." >&2; \
 		exit 1; \
 	fi
+	$(eval GITDESCRIBE := $(shell git describe --dirty --abbrev=7 --tags --always --first-parent 2>/dev/null || true))
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed "s/{modules,[[:space:]]*\[\]}/{modules, \[$(MODULES)\]}/" \
+		| sed "s/{id,[[:space:]]*\"git\"}/{id, \"$(GITDESCRIBE)\"}/" \
 		> ebin/$(PROJECT).app
 
 define compile_erl

--- a/erlang.mk
+++ b/erlang.mk
@@ -217,8 +217,10 @@ app:: erlc-include ebin/$(PROJECT).app
 		echo "Empty modules entry not found in $(PROJECT).app.src. Please consult the erlang.mk README for instructions." >&2; \
 		exit 1; \
 	fi
+	$(eval GITDESCRIBE := $(shell git describe --dirty --abbrev=7 --tags --always --first-parent 2>/dev/null || true))
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed "s/{modules,[[:space:]]*\[\]}/{modules, \[$(MODULES)\]}/" \
+		| sed "s/{id,[[:space:]]*\"git\"}/{id, \"$(GITDESCRIBE)\"}/" \
 		> ebin/$(PROJECT).app
 
 define compile_erl
@@ -278,6 +280,7 @@ help::
 bs_appsrc = "{application, $(PROJECT), [" \
 	"	{description, \"\"}," \
 	"	{vsn, \"0.1.0\"}," \
+	"	{id, \"git\"}," \
 	"	{modules, []}," \
 	"	{registered, []}," \
 	"	{applications, [" \
@@ -290,6 +293,7 @@ bs_appsrc = "{application, $(PROJECT), [" \
 bs_appsrc_lib = "{application, $(PROJECT), [" \
 	"	{description, \"\"}," \
 	"	{vsn, \"0.1.0\"}," \
+	"	{id, \"git\"}," \
 	"	{modules, []}," \
 	"	{registered, []}," \
 	"	{applications, [" \

--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -19,6 +19,7 @@ help::
 bs_appsrc = "{application, $(PROJECT), [" \
 	"	{description, \"\"}," \
 	"	{vsn, \"0.1.0\"}," \
+	"	{id, \"git\"}," \
 	"	{modules, []}," \
 	"	{registered, []}," \
 	"	{applications, [" \
@@ -31,6 +32,7 @@ bs_appsrc = "{application, $(PROJECT), [" \
 bs_appsrc_lib = "{application, $(PROJECT), [" \
 	"	{description, \"\"}," \
 	"	{vsn, \"0.1.0\"}," \
+	"	{id, \"git\"}," \
 	"	{modules, []}," \
 	"	{registered, []}," \
 	"	{applications, [" \


### PR DESCRIPTION
AFAICT this is harmless for those who don't use it, and useful for those who want it:
- if `{id, "git"}` is not present in `.app.src` then there's nothing to substitute
- if it _is_ present but we have nothing to substitute, the app file is still valid as is
- if git is not available, or git returns an error, the shell command returns true and the substitution becomes `{id, ""}`
- on a repo with no tags, you'll get something like `{id, "7fc0b40"}`
- for cowboy master, as an example, you'll get `{id, "2.0.0-pre.1-2-g14110e5"}`
- putting this in core seems sensible as if its in a plugin the `.app.src` file will need to be processed in 2 separate places
