### PR TITLE
Use erlang:halt/0 for c_src.mk

### DIFF
--- a/plugins/c_src.mk
+++ b/plugins/c_src.mk
@@ -43,7 +43,7 @@ $(C_SRC_ENV):
 	erl -noshell -noinput -eval "file:write_file(\"$(C_SRC_ENV)\", \
 		io_lib:format(\"ERTS_INCLUDE_DIR ?= ~s/erts-~s/include/\", \
 			[code:root_dir(), erlang:system_info(version)])), \
-		init:stop()."
+		erlang:halt()."
 
 -include $(C_SRC_ENV)
 


### PR DESCRIPTION
- `erlang:halt/0` is much faster than `init:stop/0` to terminate execution (no wait time)
