### PR TITLE
Prevent (some) files from being compiled by core/erlc.mk

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ variable. It takes the arguments that will then be passed to
 You can specify a list of modules to be compiled first using
 the `COMPILE_FIRST` variable.
 
+You can also use the `ERLC_EXCLUDE` variable to prevent some
+modules from being compiled by the core compiler. Note that
+`ERLC_EXCLUDE` is a list of module names (i.e., no file extension
+is required).
+
 If `{id, "git"},` is found in your project's `.app.src`, the
 extended output of `git describe ...` will replace it. This
 can be retrieved at runtime via `application:get_key/2`.

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -9,13 +9,16 @@ ERLC_OPTS ?= -Werror +debug_info +warn_export_all +warn_export_vars \
 	+warn_shadow_vars +warn_obsolete_guard # +bin_opt_info +warn_missing_spec
 COMPILE_FIRST ?=
 COMPILE_FIRST_PATHS = $(addprefix src/,$(addsuffix .erl,$(COMPILE_FIRST)))
+ERLC_EXCLUDE ?=
+ERLC_EXCLUDE_PATHS = $(addprefix src/,$(addsuffix .erl,$(ERLC_EXCLUDE)))
 
 # Verbosity.
 
 appsrc_verbose_0 = @echo " APP   " $(PROJECT).app.src;
 appsrc_verbose = $(appsrc_verbose_$(V))
 
-erlc_verbose_0 = @echo " ERLC  " $(filter %.erl %.core,$(?F));
+erlc_verbose_0 = @echo " ERLC  " $(filter-out $(patsubst %,%.erl,$(ERLC_EXCLUDE)),\
+	$(filter %.erl %.core,$(?F)));
 erlc_verbose = $(erlc_verbose_$(V))
 
 xyrl_verbose_0 = @echo " XYRL  " $(filter %.xrl %.yrl,$(?F));
@@ -38,7 +41,8 @@ app:: erlc-include ebin/$(PROJECT).app
 
 define compile_erl
 	$(erlc_verbose) erlc -v $(ERLC_OPTS) -o ebin/ \
-		-pa ebin/ -I include/ $(COMPILE_FIRST_PATHS) $(1)
+		-pa ebin/ -I include/ $(filter-out $(ERLC_EXCLUDE_PATHS),\
+		$(COMPILE_FIRST_PATHS) $(1))
 endef
 
 define compile_xyrl

--- a/erlang.mk
+++ b/erlang.mk
@@ -198,13 +198,16 @@ ERLC_OPTS ?= -Werror +debug_info +warn_export_all +warn_export_vars \
 	+warn_shadow_vars +warn_obsolete_guard # +bin_opt_info +warn_missing_spec
 COMPILE_FIRST ?=
 COMPILE_FIRST_PATHS = $(addprefix src/,$(addsuffix .erl,$(COMPILE_FIRST)))
+ERLC_EXCLUDE ?=
+ERLC_EXCLUDE_PATHS = $(addprefix src/,$(addsuffix .erl,$(ERLC_EXCLUDE)))
 
 # Verbosity.
 
 appsrc_verbose_0 = @echo " APP   " $(PROJECT).app.src;
 appsrc_verbose = $(appsrc_verbose_$(V))
 
-erlc_verbose_0 = @echo " ERLC  " $(filter %.erl %.core,$(?F));
+erlc_verbose_0 = @echo " ERLC  " $(filter-out $(patsubst %,%.erl,$(ERLC_EXCLUDE)),\
+	$(filter %.erl %.core,$(?F)));
 erlc_verbose = $(erlc_verbose_$(V))
 
 xyrl_verbose_0 = @echo " XYRL  " $(filter %.xrl %.yrl,$(?F));
@@ -227,7 +230,8 @@ app:: erlc-include ebin/$(PROJECT).app
 
 define compile_erl
 	$(erlc_verbose) erlc -v $(ERLC_OPTS) -o ebin/ \
-		-pa ebin/ -I include/ $(COMPILE_FIRST_PATHS) $(1)
+		-pa ebin/ -I include/ $(filter-out $(ERLC_EXCLUDE_PATHS),\
+		$(COMPILE_FIRST_PATHS) $(1))
 endef
 
 define compile_xyrl


### PR DESCRIPTION
This PR extends the `erlc` core plugin by adding a new variable (i.e., `ERLC_EXCL`), which can be used to specify a list of `*.erl` files that won't be compiled by `core/erlc`.

I recently stumbled upon the need for something like this in one of the projects I am working on. In that project, one of my modules implements a parse transform, and the rest of the modules are deemed to be parse transformed by the former.

Using the `COMPILE_FIRST` did not solve the problem because `core/erlc` would still try to compile the module implementing the parse transform using the `+'{parse_transform, <module-name>'}` option (as per specified in `ERLC_OPTS`).

I don't know how common this case is. If it happens to be a rare scenario, it may not make sense to merge this into `erlc/core`.
