### PR TITLE
Support dependencies fetched as git submodules

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -43,7 +43,9 @@ distclean:: distclean-deps distclean-pkg
 # Deps related targets.
 
 define dep_fetch
-	if [ "$$$$VS" = "git" ]; then \
+	if [ "$$$$VS" = "git" -a "$$$$REPO" = "submodule" ]; then \
+		git submodule update --init -- $(DEPS_DIR)/$(1); \
+	elif [ "$$$$VS" = "git" ]; then \
 		git clone -n -- $$$$REPO $(DEPS_DIR)/$(1); \
 		cd $(DEPS_DIR)/$(1) && git checkout -q $$$$COMMIT; \
 	elif [ "$$$$VS" = "hg" ]; then \

--- a/erlang.mk
+++ b/erlang.mk
@@ -148,7 +148,9 @@ distclean:: distclean-deps distclean-pkg
 # Deps related targets.
 
 define dep_fetch
-	if [ "$$$$VS" = "git" ]; then \
+	if [ "$$$$VS" = "git" -a "$$$$REPO" = "submodule" ]; then \
+		git submodule update --init -- $(DEPS_DIR)/$(1); \
+	elif [ "$$$$VS" = "git" ]; then \
 		git clone -n -- $$$$REPO $(DEPS_DIR)/$(1); \
 		cd $(DEPS_DIR)/$(1) && git checkout -q $$$$COMMIT; \
 	elif [ "$$$$VS" = "hg" ]; then \


### PR DESCRIPTION
This adds an alternative argument, 'submodule', as an alternative to a
URL for git dependencies. For example:

dep_cowboy = git submodule

This option is not propagated to sub-dependencies and all required
submodules should be added to the root repository.

The main benefit is that in later version of git, all references are
stored in the main repositories directory (i.e. .git/modules). This
allows for speedy clean and build without remote cloning every time.