### PR TITLE
Make it possible to create erlydtl beam files with full path in the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,14 @@ ErlyDTL plugin
 
 This plugin is available by default. It adds automatic
 compilation of ErlyDTL templates found in `templates/*.dtl`
-or any subdirectory.
+or any subdirectory. 
+
+By default it ignores names of subdirectories and compiles 
+`a/b/templatename.dtl` into `templatename_dtl.beam`. To include 
+subdirectories names in the compiled module name add 
+`DTL_FULL_PATH=1` into your Makefile - `a/b/templatename.dtl`
+will be compiled into `a_b_templatename_dtl.beam`.
+
 
 Relx plugin
 -----------

--- a/erlang.mk
+++ b/erlang.mk
@@ -738,6 +738,10 @@ distclean-elvis:
 # Copyright (c) 2013-2014, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+# Configuration.
+
+DTL_FULL_PATH ?= 0
+
 # Verbosity.
 
 dtl_verbose_0 = @echo " DTL   " $(filter %.dtl,$(?F));
@@ -748,9 +752,11 @@ dtl_verbose = $(dtl_verbose_$(V))
 define compile_erlydtl
 	$(dtl_verbose) erl -noshell -pa ebin/ $(DEPS_DIR)/erlydtl/ebin/ -eval ' \
 		Compile = fun(F) -> \
-			Module = list_to_atom( \
-				string:to_lower(filename:basename(F, ".dtl")) ++ "_dtl"), \
-			erlydtl:compile(F, Module, [{out_dir, "ebin/"}]) \
+			S = fun (1) -> re:replace(filename:rootname(string:sub_string(F, 11), ".dtl"), "/",  "_",  [{return, list}, global]); \
+				(0) -> filename:basename(F, ".dtl") \
+			end, \
+			Module = list_to_atom(string:to_lower(S($(DTL_FULL_PATH))) ++ "_dtl"), \
+			{ok, _} = erlydtl:compile(F, Module, [{out_dir, "ebin/"}, return_errors, {doc_root, "templates"}]) \
 		end, \
 		_ = [Compile(F) || F <- string:tokens("$(1)", " ")], \
 		init:stop()'

--- a/plugins/erlydtl.mk
+++ b/plugins/erlydtl.mk
@@ -1,6 +1,10 @@
 # Copyright (c) 2013-2014, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+# Configuration.
+
+DTL_FULL_PATH ?= 0
+
 # Verbosity.
 
 dtl_verbose_0 = @echo " DTL   " $(filter %.dtl,$(?F));
@@ -11,9 +15,11 @@ dtl_verbose = $(dtl_verbose_$(V))
 define compile_erlydtl
 	$(dtl_verbose) erl -noshell -pa ebin/ $(DEPS_DIR)/erlydtl/ebin/ -eval ' \
 		Compile = fun(F) -> \
-			Module = list_to_atom( \
-				string:to_lower(filename:basename(F, ".dtl")) ++ "_dtl"), \
-			erlydtl:compile(F, Module, [{out_dir, "ebin/"}]) \
+			S = fun (1) -> re:replace(filename:rootname(string:sub_string(F, 11), ".dtl"), "/",  "_",  [{return, list}, global]); \
+				(0) -> filename:basename(F, ".dtl") \
+			end, \
+			Module = list_to_atom(string:to_lower(S($(DTL_FULL_PATH))) ++ "_dtl"), \
+			{ok, _} = erlydtl:compile(F, Module, [{out_dir, "ebin/"}, return_errors, {doc_root, "templates"}]) \
 		end, \
 		_ = [Compile(F) || F <- string:tokens("$(1)", " ")], \
 		init:stop()'


### PR DESCRIPTION
if DTL_FULL_PATH=true
  /templates/a/b/c.dtl -> a_b_c_dtl.beam
otherwise (as it was before)
  -> c_dtl.beam

With this change it will be possible to create templates with the same name in different directories.