### PR TITLE
plugins/c_src.mk: use non-regex file extention detection and OS X LDFLAGS fix

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -592,8 +592,9 @@ C_SRC_OUTPUT ?= $(CURDIR)/priv/$(PROJECT).so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -flat_namespace -undefined suppress -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -flat_namespace -undefined suppress -finline-functions -Wall
+	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
+	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes

--- a/plugins/c_src.mk
+++ b/plugins/c_src.mk
@@ -15,8 +15,9 @@ C_SRC_OUTPUT ?= $(CURDIR)/priv/$(PROJECT).so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -flat_namespace -undefined suppress -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -flat_namespace -undefined suppress -finline-functions -Wall
+	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
+	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes


### PR DESCRIPTION
- The `-regex` option of `find` command to determine `SOURCES` in
  plugins/c_src.mk`is not portable; does not work on OS X.
  Rewrite with a portable form of using`find`native`-name`
  command option with`(`,`-o`, and`)`.
- Support file extentions of `*.c`, `*.C`, `*.cc`, `*.cpp`.
- Add LDFLAGS for OS X for proper NIF linking.
