### PR TITLE
Avoid hardcoding escript paths and add ESCRIPT_MAIN_MODULE

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ from your application and its dependencies:
 There are a number of optional configuration parameters:
 
 * `ESCRIPT_NAME` if a different output file is required
+* `ESCRIPT_MAIN_MODULE` to specify the module which contains the `main/1` function
 * `ESCRIPT_COMMENT` to alter the comment line in the escript header
 * `ESCRIPT_BEAMS` for the paths searched for `*.beam` files to include
 * `ESCRIPT_SYS_CONFIG` defaults to `rel/sys.config`

--- a/erlang.mk
+++ b/erlang.mk
@@ -899,6 +899,7 @@ endif
 # Configuration.
 
 ESCRIPT_NAME ?= $(PROJECT)
+ESCRIPT_MAIN_MODULE ?= $(PROJECT)
 ESCRIPT_COMMENT ?= This is an -*- erlang -*- file
 
 ESCRIPT_BEAMS ?= "$(realpath ebin)/*", "$(DEPS_DIR)/*/ebin/*"
@@ -906,7 +907,7 @@ ESCRIPT_SYS_CONFIG ?= "rel/sys.config"
 ESCRIPT_EMU_ARGS ?= -pa . \
 	-noshell -noinput  \
 	-sasl errlog_type error \
-	-escript main $(ESCRIPT_NAME)
+	-escript main $(ESCRIPT_MAIN_MODULE)
 ESCRIPT_SHEBANG ?= /usr/bin/env escript
 ESCRIPT_STATIC ?= "$(DEPS_DIR)/*/priv/**", "$(realpath priv)/**"
 

--- a/plugins/escript.mk
+++ b/plugins/escript.mk
@@ -6,6 +6,7 @@
 # Configuration.
 
 ESCRIPT_NAME ?= $(PROJECT)
+ESCRIPT_MAIN_MODULE ?= $(PROJECT)
 ESCRIPT_COMMENT ?= This is an -*- erlang -*- file
 
 ESCRIPT_BEAMS ?= "$(realpath ebin)/*", "$(DEPS_DIR)/*/ebin/*"
@@ -13,7 +14,7 @@ ESCRIPT_SYS_CONFIG ?= "rel/sys.config"
 ESCRIPT_EMU_ARGS ?= -pa . \
 	-noshell -noinput  \
 	-sasl errlog_type error \
-	-escript main $(ESCRIPT_NAME)
+	-escript main $(ESCRIPT_MAIN_MODULE)
 ESCRIPT_SHEBANG ?= /usr/bin/env escript
 ESCRIPT_STATIC ?= "$(DEPS_DIR)/*/priv/**", "$(realpath priv)/**"
 


### PR DESCRIPTION
This PR allows you to specify which module the `main/1` function is defined in and fixes some hardcoded paths in the escript plug-in.
