### PR TITLE
Recompile on hrl changes without touching source files

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -1012,7 +1012,7 @@ distclean-relx:
 
 # Configuration.
 
-SHELL_PATH ?= -pa ../$(PROJECT)/ebin $(DEPS_DIR)/*/ebin
+SHELL_PATH ?= -pa ./ebin $(DEPS_DIR)/*/ebin
 SHELL_OPTS ?=
 
 ALL_SHELL_DEPS_DIRS = $(addprefix $(DEPS_DIR)/,$(SHELL_DEPS))


### PR DESCRIPTION
The prior behavior modified source files (using touch) to trigger
a recompile whenever a hrl file was changed. This confuses editors,
which think the source files were actually changed by someone else.

The new approach set the date of the *.app file back to 00/01/01,
which has the same effect without confusing editors.
