### PR TITLE
Recompile on hrl changes without touching source files

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -290,7 +290,9 @@ clean:: clean-app
 
 erlc-include:
 	-@if [ -d ebin/ ]; then \
-		find include/ src/ -type f -name \*.hrl -newer ebin -exec touch $(shell find src/ -type f -name "*.erl") \; 2>/dev/null || printf ''; \
+		if [ ! -z "`find include/ src/ -type f -name \*.hrl -newer ebin 2> /dev/null`" ]; then \
+			touch -t 0001010000 ebin/*.app; \
+		fi \
 	fi
 
 clean-app:


### PR DESCRIPTION
The prior behavior modified source files (using touch) to trigger
a recompile whenever a hrl file was changed. This confuses editors,
which think the source files were actually changed by someone else.

The new approach set the date of the *.app file back to 00/01/01,
which has the same effect without confusing editors.