### PR TITLE
Using ./ebin in shell path rather than ../$(PROJECT)/ebin

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -1010,7 +1010,7 @@ distclean-relx:
 
 # Configuration.
 
-SHELL_PATH ?= -pa ../$(PROJECT)/ebin $(DEPS_DIR)/*/ebin
+SHELL_PATH ?= -pa ./ebin $(DEPS_DIR)/*/ebin
 SHELL_OPTS ?=
 
 ALL_SHELL_DEPS_DIRS = $(addprefix $(DEPS_DIR)/,$(SHELL_DEPS))


### PR DESCRIPTION
The previous behavior is wrong when the project directory is not the
same name as the application.
