### PR TITLE
Update version when building erlang.mk.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,13 @@ BUILD_CONFIG_FILE ?= $(CURDIR)/build.config
 BUILD_CONFIG = $(shell sed "s/\#.*//" $(BUILD_CONFIG_FILE))
 
 ERLANG_MK = erlang.mk
+ERLANG_MK_VERSION = $(shell git describe --tags --dirty)
 
 .PHONY: all
 
 all: pkg
-	awk 'FNR==1 && NR!=1{print ""}1' $(patsubst %,%.mk,$(BUILD_CONFIG)) > $(ERLANG_MK)
+	awk 'FNR==1 && NR!=1{print ""}1' $(patsubst %,%.mk,$(BUILD_CONFIG)) \
+	| sed 's/^ERLANG_MK_VERSION = .*/ERLANG_MK_VERSION = $(ERLANG_MK_VERSION)/' > $(ERLANG_MK)
 
 pkg:
 	cat packages.v2.tsv | awk 'BEGIN { FS = "\t" }; { print $$1 "\t" $$3 "\t" $$5 "\t" $$6 }' > packages.v1.tsv

--- a/erlang.mk
+++ b/erlang.mk
@@ -14,7 +14,7 @@
 
 .PHONY: all deps app rel docs tests clean distclean help erlang-mk
 
-ERLANG_MK_VERSION = 1
+ERLANG_MK_VERSION = 1.2.0-37-g5fef667-dirty
 
 # Core configuration.
 


### PR DESCRIPTION
For me, I like to know which version I have, when running `make help` for instance.
