### PR TITLE
Build deps, app, rel targets really in that order

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -75,11 +75,11 @@ ebin/$(PROJECT).app:: $(shell find mibs -type f -name \*.mib)
 endif
 
 ebin/$(PROJECT).app:: $(shell find src -type f -name \*.erl) \
-		$(shell find src -type f -name \*.core)
+		$(shell find src -type f -name \*.core) | deps
 	$(if $(strip $?),$(call compile_erl,$?))
 
 ebin/$(PROJECT).app:: $(shell find src -type f -name \*.xrl) \
-		$(shell find src -type f -name \*.yrl)
+		$(shell find src -type f -name \*.yrl) | deps
 	$(if $(strip $?),$(call compile_xyrl,$?))
 endif
 

--- a/erlang.mk
+++ b/erlang.mk
@@ -276,11 +276,11 @@ ebin/$(PROJECT).app:: $(shell find mibs -type f -name \*.mib)
 endif
 
 ebin/$(PROJECT).app:: $(shell find src -type f -name \*.erl) \
-		$(shell find src -type f -name \*.core)
+		$(shell find src -type f -name \*.core) | deps
 	$(if $(strip $?),$(call compile_erl,$?))
 
 ebin/$(PROJECT).app:: $(shell find src -type f -name \*.xrl) \
-		$(shell find src -type f -name \*.yrl)
+		$(shell find src -type f -name \*.yrl) | deps
 	$(if $(strip $?),$(call compile_xyrl,$?))
 endif
 
@@ -1116,7 +1116,7 @@ endef
 $(RELX):
 	@$(call relx_fetch)
 
-relx-rel: $(RELX)
+relx-rel: $(RELX) | deps app
 	@$(RELX) -c $(RELX_CONFIG) $(RELX_OPTS)
 
 distclean-relx-rel:

--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -38,7 +38,7 @@ endef
 $(RELX):
 	@$(call relx_fetch)
 
-relx-rel: $(RELX)
+relx-rel: $(RELX) | deps app
 	@$(RELX) -c $(RELX_CONFIG) $(RELX_OPTS)
 
 distclean-relx-rel:


### PR DESCRIPTION
This pull requests adds the power of [order-only prerequisites](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html) feature of GNU make to erlang.mk.
The code is built really after its dependencies.
This fixes the need of multiple make runs with ```MAKEFLAGS=-j32```