### PR TITLE
add subversion dependency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ dep_cowboy = git https://github.com/ninenines/cowboy 1.0.0
 They will always be compiled using the command `make`. If the dependency
 does not feature a Makefile, then erlang.mk will be used for building.
 
+For subversion dependencies, the url specifies trunk, branch or
+tag. To specify a particular revision, use `@revision` at the end of
+the url. No separate specification of branch, tag, or revision is
+required or possible.
+
+``` erlang
+DEPS = ex1 ex2
+dep_ex1 = svn https://example.com/svn/trunk/project/ex1
+dep_ex2 = svn svn://example.com/svn/branches/erlang-proj/ex2@264
+```
+
 You can also specify test-only dependencies. These dependencies will only
 be downloaded when running `make tests`. The format is the same as above,
 except the variable `TEST_DEPS` holds the list of test-only dependencies.

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -49,6 +49,8 @@ define dep_fetch
 	elif [ "$$$$VS" = "hg" ]; then \
 		hg clone -U $$$$REPO $(DEPS_DIR)/$(1); \
 		cd $(DEPS_DIR)/$(1) && hg update -q $$$$COMMIT; \
+	elif [ "$$$$VS" = "svn" ]; then \
+		svn checkout $$$$REPO $(DEPS_DIR)/$(1); \
 	else \
 		echo "Unknown or invalid dependency: $(1). Please consult the erlang.mk README for instructions." >&2; \
 		exit 78; \

--- a/erlang.mk
+++ b/erlang.mk
@@ -135,6 +135,8 @@ define dep_fetch
 	elif [ "$$$$VS" = "hg" ]; then \
 		hg clone -U $$$$REPO $(DEPS_DIR)/$(1); \
 		cd $(DEPS_DIR)/$(1) && hg update -q $$$$COMMIT; \
+	elif [ "$$$$VS" = "svn" ]; then \
+		svn checkout $$$$REPO $(DEPS_DIR)/$(1); \
 	else \
 		echo "Unknown or invalid dependency: $(1). Please consult the erlang.mk README for instructions." >&2; \
 		exit 78; \


### PR DESCRIPTION
This PR is much smaller than my previous attempt. The 'present' specification was removed and the 'svn' one simplified significantly.
Because svn URLs can specify trunk/branch/tag and revision, there is no separate specification of revision. This is documented briefly in README.md. I don't have any public svn material to make available in the packages file.
From distant memory, I'll wish you Joyeux Noël, et bonne Nouvelle Année.
