### PR TITLE
Allowing skipping deps target

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -30,6 +30,8 @@ PKG_FILE_URL ?= https://raw.githubusercontent.com/ninenines/erlang.mk/master/pac
 # Core targets.
 
 deps:: $(ALL_DEPS_DIRS)
+ifeq ($(SKIP_DEPS),true)
+else
 	@for dep in $(ALL_DEPS_DIRS) ; do \
 		if [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ] ; then \
 			$(MAKE) -C $$dep ; \
@@ -37,6 +39,7 @@ deps:: $(ALL_DEPS_DIRS)
 			echo "include $(CURDIR)/erlang.mk" | ERLC_OPTS=+debug_info $(MAKE) -f - -C $$dep ; \
 		fi ; \
 	done
+endif
 
 distclean:: distclean-deps distclean-pkg
 

--- a/erlang.mk
+++ b/erlang.mk
@@ -116,6 +116,8 @@ PKG_FILE_URL ?= https://raw.githubusercontent.com/ninenines/erlang.mk/master/pac
 # Core targets.
 
 deps:: $(ALL_DEPS_DIRS)
+ifeq ($(SKIP_DEPS),true)
+else
 	@for dep in $(ALL_DEPS_DIRS) ; do \
 		if [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ] ; then \
 			$(MAKE) -C $$dep ; \
@@ -123,6 +125,7 @@ deps:: $(ALL_DEPS_DIRS)
 			echo "include $(CURDIR)/erlang.mk" | ERLC_OPTS=+debug_info $(MAKE) -f - -C $$dep ; \
 		fi ; \
 	done
+endif
 
 distclean:: distclean-deps distclean-pkg
 


### PR DESCRIPTION
Same effect as rebar's "skip_deps=true". Particularly handy when running the eunit task (~1s vs ~6s, on my machine). There's probably a better way to accomplish this, but I'd really like the feature :)