### PR TITLE
Allow there be no _SUITE in test/.

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -783,7 +783,7 @@ build-ct-suites: build-ct-deps
 
 tests-ct: ERLC_OPTS = $(TEST_ERLC_OPTS)
 tests-ct: clean deps app build-ct-suites
-	@if [ -d "test" ] ; \
+	@if [ -d "test" ] && [ -n "$(CT_SUITES)" ] ; \
 	then \
 		mkdir -p logs/ ; \
 		$(CT_RUN) -suite $(addsuffix _SUITE,$(CT_SUITES)) $(CT_OPTS) ; \
@@ -793,7 +793,7 @@ tests-ct: clean deps app build-ct-suites
 define ct_suite_target
 ct-$(1): ERLC_OPTS = $(TEST_ERLC_OPTS)
 ct-$(1): clean deps app build-ct-suites
-	@if [ -d "test" ] ; \
+	@if [ -d "test" ] && [ -n "$(1)" ] ; \
 	then \
 		mkdir -p logs/ ; \
 		$(CT_RUN) -suite $(addsuffix _SUITE,$(1)) $(CT_OPTS) ; \


### PR DESCRIPTION
There exist a convention to put eunit test codes under test/ directory.  Better to allow this and suppress warnings that there is no ct_suites specified.
