### PR TITLE
Prevent 'make all' from removing elvis

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -943,10 +943,6 @@ help::
 		"Elvis targets:" \
 		"  elvis       Run Elvis using the local elvis.config or download the default otherwise"
 
-ifneq ($(wildcard $(ELVIS_CONFIG)),)
-rel:: distclean-elvis
-endif
-
 distclean:: distclean-elvis
 
 # Plugin-specific targets.

--- a/plugins/elvis.mk
+++ b/plugins/elvis.mk
@@ -21,10 +21,6 @@ help::
 		"Elvis targets:" \
 		"  elvis       Run Elvis using the local elvis.config or download the default otherwise"
 
-ifneq ($(wildcard $(ELVIS_CONFIG)),)
-rel:: distclean-elvis
-endif
-
 distclean:: distclean-elvis
 
 # Plugin-specific targets.


### PR DESCRIPTION
Given that 'make all' is the default build, it seems surprising to
delete this without an explicit request for a 'distclean'.

@jfacorro could perhaps shed some light on why this behaviour
was initially included.