### PR TITLE
Fix pkg-search typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The following targets are specific to packages:
 
 `pkg-list` lists all packages in the index.
 
-`pkg-search n=STRING` searches the index for STRING.
+`pkg-search q=STRING` searches the index for STRING.
 
 Packages are downloaded into `DEPS_DIR` (`./deps/` by default).
 


### PR DESCRIPTION
I just spotted this `pkg-search n=STRING` typo in the README. 
Sorry about the spaces. I can restore them if you want.