### PR TITLE
Require makefile to build dep. Fixes #218.

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -35,7 +35,7 @@ PKG_FILE_URL ?= https://raw.githubusercontent.com/ninenines/erlang.mk/master/pac
 deps:: $(ALL_DEPS_DIRS)
 	@for dep in $(ALL_DEPS_DIRS) ; do \
 		if [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ] ; then \
-			$(MAKE) -C $$dep ; \
+			$(MAKE) -C $$dep || exit $$? ; \
 		else \
 			echo "ERROR: No makefile to build dependency $$dep. Consider adding it to AUTOPATCH." ; \
 			exit 1 ; \

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -37,7 +37,8 @@ deps:: $(ALL_DEPS_DIRS)
 		if [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ] ; then \
 			$(MAKE) -C $$dep ; \
 		else \
-			echo "include $(CURDIR)/erlang.mk" | ERLC_OPTS=+debug_info $(MAKE) -f - -C $$dep ; \
+			echo "ERROR: No makefile to build dependency $$dep. Consider adding it to AUTOPATCH." ; \
+			exit 1 ; \
 		fi ; \
 	done
 

--- a/erlang.mk
+++ b/erlang.mk
@@ -142,7 +142,8 @@ deps:: $(ALL_DEPS_DIRS)
 		if [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ] ; then \
 			$(MAKE) -C $$dep ; \
 		else \
-			echo "include $(CURDIR)/erlang.mk" | ERLC_OPTS=+debug_info $(MAKE) -f - -C $$dep ; \
+			echo "ERROR: No makefile to build dependency $$dep. Consider adding it to AUTOPATCH." ; \
+			exit 1 ; \
 		fi ; \
 	done
 

--- a/erlang.mk
+++ b/erlang.mk
@@ -140,7 +140,7 @@ PKG_FILE_URL ?= https://raw.githubusercontent.com/ninenines/erlang.mk/master/pac
 deps:: $(ALL_DEPS_DIRS)
 	@for dep in $(ALL_DEPS_DIRS) ; do \
 		if [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ] ; then \
-			$(MAKE) -C $$dep ; \
+			$(MAKE) -C $$dep || exit $$? ; \
 		else \
 			echo "ERROR: No makefile to build dependency $$dep. Consider adding it to AUTOPATCH." ; \
 			exit 1 ; \


### PR DESCRIPTION
Print helpful error message in case a dependency doesn't have a Makefile to build it.
