### PR TITLE
Packages: rename exsplus to exsplus128

### DIFF
--- a/packages.v1.tsv
+++ b/packages.v1.tsv
@@ -23,7 +23,7 @@ erlydtl	https://github.com/erlydtl/erlydtl	https://github.com/erlydtl/erlydtl	Dj
 erwa	https://github.com/bwegh/erwa	https://github.com/bwegh/erwa	A WAMP router and client written in Erlang.
 exs1024	https://github.com/jj1bdx/exs1024	https://github.com/jj1bdx/exs1024	Xorshift1024star pseudo random number generator for Erlang.
 exs64	https://github.com/jj1bdx/exs64	https://github.com/jj1bdx/exs64	Xorshift64star pseudo random number generator for Erlang.
-exsplus	https://github.com/jj1bdx/exsplus	https://github.com/jj1bdx/exsplus	Xorshift128plus pseudo random number generator for Erlang.
+exsplus128	https://github.com/jj1bdx/exsplus128	https://github.com/jj1bdx/exsplus128	Xorshift128plus pseudo random number generator for Erlang.
 feeder	https://github.com/michaelnisi/feeder	https://github.com/michaelnisi/feeder	Stream parse RSS and Atom formatted XML feeds.
 geas	https://github.com/crownedgrouse/geas.git	https://github.com/crownedgrouse/geas	Guess Erlang Application Scattering
 getopt	https://github.com/jcomellas/getopt.git	https://github.com/jcomellas/getopt	Module to parse command line arguments using the GNU getopt syntax

--- a/packages.v1.txt
+++ b/packages.v1.txt
@@ -23,7 +23,7 @@ erlydtl	https://github.com/erlydtl/erlydtl	https://github.com/erlydtl/erlydtl	Dj
 erwa	https://github.com/bwegh/erwa	https://github.com/bwegh/erwa	A WAMP router and client written in Erlang.
 exs1024	https://github.com/jj1bdx/exs1024	https://github.com/jj1bdx/exs1024	Xorshift1024star pseudo random number generator for Erlang.
 exs64	https://github.com/jj1bdx/exs64	https://github.com/jj1bdx/exs64	Xorshift64star pseudo random number generator for Erlang.
-exsplus	https://github.com/jj1bdx/exsplus	https://github.com/jj1bdx/exsplus	Xorshift128plus pseudo random number generator for Erlang.
+exsplus128	https://github.com/jj1bdx/exsplus128	https://github.com/jj1bdx/exsplus128	Xorshift128plus pseudo random number generator for Erlang.
 feeder	https://github.com/michaelnisi/feeder	https://github.com/michaelnisi/feeder	Stream parse RSS and Atom formatted XML feeds.
 geas	https://github.com/crownedgrouse/geas.git	https://github.com/crownedgrouse/geas	Guess Erlang Application Scattering
 getopt	https://github.com/jcomellas/getopt.git	https://github.com/jcomellas/getopt	Module to parse command line arguments using the GNU getopt syntax

--- a/packages.v2.tsv
+++ b/packages.v2.tsv
@@ -23,7 +23,7 @@ erlydtl	git	https://github.com/erlydtl/erlydtl	master	https://github.com/erlydtl
 erwa	git	https://github.com/bwegh/erwa	0.1.1	https://github.com/bwegh/erwa	A WAMP router and client written in Erlang.
 exs1024	git	https://github.com/jj1bdx/exs1024	master	https://github.com/jj1bdx/exs1024	Xorshift1024star pseudo random number generator for Erlang.
 exs64	git	https://github.com/jj1bdx/exs64	master	https://github.com/jj1bdx/exs64	Xorshift64star pseudo random number generator for Erlang.
-exsplus	git	https://github.com/jj1bdx/exsplus	master	https://github.com/jj1bdx/exsplus	Xorshift128plus pseudo random number generator for Erlang.
+exsplus128	git	https://github.com/jj1bdx/exsplus128	master	https://github.com/jj1bdx/exsplus128	Xorshift128plus pseudo random number generator for Erlang.
 feeder	git	https://github.com/michaelnisi/feeder	1.4.2	https://github.com/michaelnisi/feeder	Stream parse RSS and Atom formatted XML feeds.
 geas	git	https://github.com/crownedgrouse/geas.git	master	https://github.com/crownedgrouse/geas	Guess Erlang Application Scattering
 getopt	git	https://github.com/jcomellas/getopt.git	master	https://github.com/jcomellas/getopt	Module to parse command line arguments using the GNU getopt syntax


### PR DESCRIPTION
The following package is renamed and the packages.* files are duly updated. The renamed package: https://github.com/jj1bdx/exsplus128/