### PR TITLE
Build NIF C code also on tests

### DIFF
--- a/plugins/c_src.mk
+++ b/plugins/c_src.mk
@@ -48,7 +48,11 @@ link_verbose = $(link_verbose_$(V))
 
 ifeq ($(wildcard $(C_SRC_DIR)),)
 else ifneq ($(wildcard $(C_SRC_DIR)/Makefile),)
-app::
+app:: app-c_src
+
+test-build:: app-c_src
+
+app-c_src:
 	$(MAKE) -C $(C_SRC_DIR) \
 		CFLAGS="$(CFLAGS)" \
 		CXXFLAGS="$(CXXFLAGS)" \
@@ -66,6 +70,8 @@ COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
 COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
 
 app:: $(C_SRC_ENV) $(C_SRC_OUTPUT)
+
+test-build:: $(C_SRC_ENV) $(C_SRC_OUTPUT)
 
 $(C_SRC_OUTPUT): $(OBJECTS)
 	@mkdir -p priv/


### PR DESCRIPTION
* This patch ensures building the NIF code under`c_src`
  even on running `make tests`

* When `c_src/Makefile` exists:
    * Split the Makefile invocation dependency into `app-c_src`
    * Invoke `app-c_src` also in `test-build` as well as `app`
* When `c_src/Makefile` does not exist:
    * Add `$(C_SRC_ENV) $(C_SRC_OUTPUT)` dependencies to `test-build`