### PR TITLE
Fix test/Makefile for FreeBSD shell redirection compatibility

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -14,12 +14,12 @@ V ?= 0
 ifeq ($V,0)
 	# Show info messages only
 	t = @
-	v = V=0 &>/dev/null
+	v = V=0 >/dev/null 2>&1
 	i = @echo
 else ifeq ($V,1)
 	# Show test commands
 	t =
-	v = V=0 &>/dev/null
+	v = V=0 >/dev/null 2>&1
 	i = @echo ==
 else ifeq ($V,2)
 	# Show briefly what erlang.mk is doing


### PR DESCRIPTION
* FreeBSD shell does not accept `&>` as the redirect operator;
  Explicitly rewrite `&>/dev/null` to `>/dev/null 2>&1`
  as a workaround
* This will not break other shells (confirmed on OS X 10.10.3)