### PR TITLE
Add package edown to the index

### DIFF
--- a/packages.v1.tsv
+++ b/packages.v1.tsv
@@ -64,6 +64,7 @@ edate	https://github.com/dweldon/edate	https://github.com/dweldon/edate	date man
 edgar	https://github.com/crownedgrouse/edgar	https://github.com/crownedgrouse/edgar	Erlang Does GNU AR
 edis	https://github.com/inaka/edis	http://inaka.github.com/edis/	An Erlang implementation of Redis KV Store
 edns	https://github.com/hcvst/erlang-dns	https://github.com/hcvst/erlang-dns	Erlang/OTP DNS server
+edown	https://github.com/uwiger/edown	https://github.com/uwiger/edown	EDoc extension for generating Github-flavored Markdown
 eep_app	https://github.com/darach/eep-erl	https://github.com/darach/eep-erl	Embedded Event Processing
 eep	https://github.com/virtan/eep	https://github.com/virtan/eep	Erlang Easy Profiling (eep) application provides a way to analyze application performance and call hierarchy
 efene	https://github.com/efene/efene	https://github.com/efene/efene	Alternative syntax for the Erlang Programming Language focusing on simplicity, ease of use and programmer UX

--- a/packages.v1.txt
+++ b/packages.v1.txt
@@ -64,6 +64,7 @@ edate	https://github.com/dweldon/edate	https://github.com/dweldon/edate	date man
 edgar	https://github.com/crownedgrouse/edgar	https://github.com/crownedgrouse/edgar	Erlang Does GNU AR
 edis	https://github.com/inaka/edis	http://inaka.github.com/edis/	An Erlang implementation of Redis KV Store
 edns	https://github.com/hcvst/erlang-dns	https://github.com/hcvst/erlang-dns	Erlang/OTP DNS server
+edown	https://github.com/uwiger/edown	https://github.com/uwiger/edown	EDoc extension for generating Github-flavored Markdown
 eep_app	https://github.com/darach/eep-erl	https://github.com/darach/eep-erl	Embedded Event Processing
 eep	https://github.com/virtan/eep	https://github.com/virtan/eep	Erlang Easy Profiling (eep) application provides a way to analyze application performance and call hierarchy
 efene	https://github.com/efene/efene	https://github.com/efene/efene	Alternative syntax for the Erlang Programming Language focusing on simplicity, ease of use and programmer UX

--- a/packages.v2.tsv
+++ b/packages.v2.tsv
@@ -64,6 +64,7 @@ edate	git	https://github.com/dweldon/edate	master	https://github.com/dweldon/eda
 edgar	git	https://github.com/crownedgrouse/edgar	master	https://github.com/crownedgrouse/edgar	Erlang Does GNU AR
 edis	git	https://github.com/inaka/edis	master	http://inaka.github.com/edis/	An Erlang implementation of Redis KV Store
 edns	git	https://github.com/hcvst/erlang-dns	master	https://github.com/hcvst/erlang-dns	Erlang/OTP DNS server
+edown	git	https://github.com/uwiger/edown	master	https://github.com/uwiger/edown	EDoc extension for generating Github-flavored Markdown
 eep_app	git	https://github.com/darach/eep-erl	master	https://github.com/darach/eep-erl	Embedded Event Processing
 eep	git	https://github.com/virtan/eep	master	https://github.com/virtan/eep	Erlang Easy Profiling (eep) application provides a way to analyze application performance and call hierarchy
 efene	git	https://github.com/efene/efene	master	https://github.com/efene/efene	Alternative syntax for the Erlang Programming Language focusing on simplicity, ease of use and programmer UX


### PR DESCRIPTION
This returns a find... error on OSX IIRC we've seen this before & I assume its unrelated to edown itself.

```
dch 🍺  /r/e/erlang.mk git:edown ❯❯❯make check p=edown
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C test pkg-edown
Setting up app.
cat packages.v2.tsv | awk 'BEGIN { FS = "\t" }; { print $1 "\t" $3 "\t" $5 "\t" $6 }' > packages.v1.tsv
cp packages.v1.tsv packages.v1.txt
awk 'FNR==1 && NR!=1{print ""}1' core/core.mk core/deps.mk plugins/protobuffs.mk core/erlc.mk core/docs.mk core/test.mk plugins/asciidoc.mk plugins/bootstrap.mk plugins/c_src.mk plugins/ci.mk plugins/ct.mk plugins/dialyzer.mk plugins/edoc.mk plugins/elvis.mk plugins/erlydtl.mk plugins/escript.mk plugins/eunit.mk plugins/relx.mk plugins/shell.mk plugins/triq.mk plugins/xref.mk plugins/cover.mk \
		| sed 's/^ERLANG_MK_VERSION = .*/ERLANG_MK_VERSION = 1.2.0-512-g06fd9a1/' > erlang.mk

  pkgs: Checking that 'edown' builds correctly

cp ../packages.v2.tsv app1/.erlang.mk.packages.v2
 DEP    edown
 ERLC   edown_doclet.erl edown_make.erl edown_xmerl.erl edown_lib.erl edown_layout.erl
 APP    edown.app.src
 ERLC   m.erl
 APP    app1.app.src
 APP    edown.app.src
 APP    app1.app.src
find: illegal option -- t
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
Loading application edown
  Loading module edown_doclet
  Loading module edown_lib
  Loading module edown_make
  Loading module edown_xmerl
  Loading module edown_layout
```
