### PR TITLE
Able to use external configuration file for CT

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -4,7 +4,8 @@ ERLANG_MK_BUILD_CONFIG ?= build.config
 ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
 erlang.mk: bootstrap
-	git clone https://github.com/ninenines/erlang.mk $(ERLANG_MK_BUILD_DIR)
+	#git clone https://github.com/ninenines/erlang.mk $(ERLANG_MK_BUILD_DIR)
+	git clone https://github.com/ethrbh/erlang.mk.git $(ERLANG_MK_BUILD_DIR)
 	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR); fi
 	cd $(ERLANG_MK_BUILD_DIR) && $(MAKE)
 	cp $(ERLANG_MK_BUILD_DIR)/erlang.mk ./erlang.mk

--- a/erlang.mk
+++ b/erlang.mk
@@ -4,8 +4,7 @@ ERLANG_MK_BUILD_CONFIG ?= build.config
 ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
 erlang.mk: bootstrap
-	#git clone https://github.com/ninenines/erlang.mk $(ERLANG_MK_BUILD_DIR)
-	git clone https://github.com/ethrbh/erlang.mk.git $(ERLANG_MK_BUILD_DIR)
+	git clone https://github.com/ninenines/erlang.mk $(ERLANG_MK_BUILD_DIR)
 	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR); fi
 	cd $(ERLANG_MK_BUILD_DIR) && $(MAKE)
 	cp $(ERLANG_MK_BUILD_DIR)/erlang.mk ./erlang.mk

--- a/plugins/ct.mk
+++ b/plugins/ct.mk
@@ -13,7 +13,7 @@ else
 endif
 
 ifneq ($(wildcard $(TEST_DIR)),)
-	CT_CFG ?= $(sort $(shell find $(TEST_DIR) -type f -name \*.cfg -exec basename {} \;))
+	CT_CFG ?= $(shell find $(TEST_DIR) -name '*.cfg')
 else
 	CT_CFG ?=
 endif
@@ -47,8 +47,8 @@ CT_RUN = ct_run \
 	-noinput \
 	-pa $(CURDIR)/ebin $(DEPS_DIR)/*/ebin $(TEST_DIR) \
 	-dir $(TEST_DIR) \
-	-logdir $(CURDIR)/logs
-	-config $(TEST_DIR)/$(CT_CFG)
+	-logdir $(CURDIR)/logs \
+	-config $(CT_CFG)
 endif
 
 

--- a/plugins/ct.mk
+++ b/plugins/ct.mk
@@ -12,6 +12,12 @@ else
 	CT_SUITES ?=
 endif
 
+ifneq ($(wildcard $(TEST_DIR)),)
+	CT_CFG ?= $(sort $(shell find $(TEST_DIR) -type f -name \*.cfg -exec basename {} \;))
+else
+	CT_CFG ?=
+endif
+
 # Core targets.
 
 tests:: ct
@@ -28,12 +34,23 @@ help::
 
 # Plugin-specific targets.
 
+ifeq ($(CT_CFG),)
 CT_RUN = ct_run \
 	-no_auto_compile \
 	-noinput \
 	-pa $(CURDIR)/ebin $(DEPS_DIR)/*/ebin $(TEST_DIR) \
 	-dir $(TEST_DIR) \
 	-logdir $(CURDIR)/logs
+else
+CT_RUN = ct_run \
+	-no_auto_compile \
+	-noinput \
+	-pa $(CURDIR)/ebin $(DEPS_DIR)/*/ebin $(TEST_DIR) \
+	-dir $(TEST_DIR) \
+	-logdir $(CURDIR)/logs
+	-config $(TEST_DIR)/$(CT_CFG)
+endif
+
 
 ifeq ($(CT_SUITES),)
 ct:


### PR DESCRIPTION
hello,

I have made a small improvement in ct.mk. This change pass external configuration files to CT when it starting. The external configuration files have two requirements:
 - the files must be placed in the test/ folder
 - must set .cfg extension for the files

Please merge the PR once you have reviewed and all looks good.

thanks for your help,
/Robi