### PR TITLE
dep_autopatch: Ensure ['s `!=` operator has operands

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -67,11 +67,11 @@ distclean:: distclean-deps distclean-pkg
 # in practice only Makefile is needed so far.
 define dep_autopatch
 	if [ -f $(DEPS_DIR)/$(1)/Makefile ]; then \
-		if [ 0 != `grep -c "include ../\w*\.mk" $(DEPS_DIR)/$(1)/Makefile` ]; then \
+		if [ x0 != x`grep -c "include ../\w*\.mk" $(DEPS_DIR)/$(1)/Makefile` ]; then \
 			$(call dep_autopatch2,$(1)); \
-		elif [ 0 != `grep -ci rebar $(DEPS_DIR)/$(1)/Makefile` ]; then \
+		elif [ x0 != x`grep -ci rebar $(DEPS_DIR)/$(1)/Makefile` ]; then \
 			$(call dep_autopatch2,$(1)); \
-		elif [ 0 != `find $(DEPS_DIR)/$(1)/ -type f -name \*.mk -not -name erlang.mk | xargs grep -ci rebar` ]; then \
+		elif [ x0 != x`find $(DEPS_DIR)/$(1)/ -type f -name \*.mk -not -name erlang.mk | xargs grep -ci rebar` ]; then \
 			$(call dep_autopatch2,$(1)); \
 		else \
 			if [ -f $(DEPS_DIR)/$(1)/erlang.mk ]; then \


### PR DESCRIPTION
Consider the following test:
```sh
elif [ 0 != `find ... | xargs grep -ci rebar` ]; then
```

find(1) may return no file at all and xargs has nothing on its stdin. In this case, GNU xargs (from findutils) still executes the given command and grep(1) returns `0`.

However, FreeBSD's xargs for instance does not run the command at all if there is nothing on stdin. Therefore nothing is printed on stdout and the test becomes:
```sh
elif [ 0 != ]; then
```

This triggers a warning from the shell:
```
[: !=: argument expected
```

Prepending both operands with a literal `x` fixes the problem.

For consistency's sake, I modified the two other tests as well, though I didn't have any problem with them.