### PR TITLE
core/deps.mk: Ensure `$(ERLANG_MK_TMP)` is created

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -43,6 +43,7 @@ deps:: $(ALL_DEPS_DIRS)
 ifneq ($(IS_DEP),1)
 	@rm -f $(ERLANG_MK_TMP)/deps.log
 endif
+	@mkdir -p $(ERLANG_MK_TMP)
 	@for dep in $(ALL_DEPS_DIRS) ; do \
 		if grep -qs ^$$dep$$$$ $(ERLANG_MK_TMP)/deps.log; then \
 			echo -n; \


### PR DESCRIPTION
... before writing to it.

This fixes the following error which is logged with a fresh checkout:
```
/bin/sh: cannot create (...)/.erlang.mk/deps.log: No such file or directory
```