### PR TITLE
The '-r' option of 'xargs' is illegal on OSX

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -170,6 +170,12 @@ core_lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,
 # @todo On Windows: $(shell dir /B $(1)); make sure to handle when no file exists.
 core_ls = $(filter-out $(1),$(shell echo $(1)))
 
+ifeq ($(PLATFORM),darwin)
+core_xargs = xargs
+else
+core_xargs = xargs -r
+endif
+
 # Automated update.
 
 ERLANG_MK_BUILD_CONFIG ?= build.config

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -67,7 +67,7 @@ define dep_autopatch
 			$(call dep_autopatch2,$(1)); \
 		elif [ 0 != `grep -ci rebar $(DEPS_DIR)/$(1)/Makefile` ]; then \
 			$(call dep_autopatch2,$(1)); \
-		elif [ -n "`find $(DEPS_DIR)/$(1)/ -type f -name \*.mk -not -name erlang.mk | xargs -r grep -i rebar`" ]; then \
+		elif [ -n "`find $(DEPS_DIR)/$(1)/ -type f -name \*.mk -not -name erlang.mk | $(call core_xargs) grep -i rebar`" ]; then \
 			$(call dep_autopatch2,$(1)); \
 		else \
 			if [ -f $(DEPS_DIR)/$(1)/erlang.mk ]; then \


### PR DESCRIPTION
```
 DEP    cowboy
xargs: illegal option -- r
usage: xargs [-0opt] [-E eofstr] [-I replstr [-R replacements]] [-J replstr]
             [-L number] [-n number [-x]] [-P maxprocs] [-s size]
             [utility [argument ...]]
```