### PR TITLE
fix manual specification of deps

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -517,9 +517,8 @@ ifeq (1,$(words $(dep_$(1))))
 		master)
 else
 ifeq (2,$(words $(dep_$(1))))
-	$(dep_verbose) $(call dep_fetch,$(1),git, \
-		$(patsubst git://github.com/%,https://github.com/%,$(word 1,$(dep_$(1)))), \
-		$(word 2,$(dep_$(1))))
+	$(dep_verbose) $(call dep_fetch,$(1),$(word 1,$(dep_$(1))), \
+		$(patsubst git://github.com/%,https://github.com/%,$(word 2,$(dep_$(1)))))
 else
 	$(dep_verbose) $(call dep_fetch,$(1),$(word 1,$(dep_$(1))), \
 		$(patsubst git://github.com/%,https://github.com/%,$(word 2,$(dep_$(1)))), \

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -517,12 +517,21 @@ ifeq (1,$(words $(dep_$(1))))
 		master)
 else
 ifeq (2,$(words $(dep_$(1))))
+ifneq ($(filter $(word 1,$(dep_$(1))),cp git hex hg sv),)
 	$(dep_verbose) $(call dep_fetch,$(1),$(word 1,$(dep_$(1))), \
 		$(patsubst git://github.com/%,https://github.com/%,$(word 2,$(dep_$(1)))))
+else
+ifeq ($(filter $(word 1,$(dep_$(1))),cp git hex hg sv),)
+	$(dep_verbose) $(call dep_fetch,$(1),git, \
+		$(patsubst git://github.com/%,https://github.com/%,$(word 1,$(dep_$(1)))), \
+		$(word 2,$(dep_$(1))))
+
 else
 	$(dep_verbose) $(call dep_fetch,$(1),$(word 1,$(dep_$(1))), \
 		$(patsubst git://github.com/%,https://github.com/%,$(word 2,$(dep_$(1)))), \
 		$(word 3,$(dep_$(1))))
+endif
+endif
 endif
 endif
 endif


### PR DESCRIPTION
when a manual dep source was specified, erlang.mk assumed it was a git source.

fix #306 

note: this fails tests (edown), but master does as well so it might not be a valid solution for the problem