### PR TITLE
Fix build config renaming

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -180,7 +180,7 @@ ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
 erlang-mk:
 	git clone https://github.com/ninenines/erlang.mk $(ERLANG_MK_BUILD_DIR)
-	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR); fi
+	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR)/build.config; fi
 	cd $(ERLANG_MK_BUILD_DIR) && $(MAKE)
 	cp $(ERLANG_MK_BUILD_DIR)/erlang.mk ./erlang.mk
 	rm -rf $(ERLANG_MK_BUILD_DIR)


### PR DESCRIPTION
Currently build.config can be placed in a different directory via
something like:

  ERLANG_MK_BUILD_CONFIG = tools/build.config

but if the name is changed:

  ERLANG_MK_BUILD_CONFIG = .erlang-mk.config

it will be ignored.