### PR TITLE
New variable ERLANG_MK_DISABLE_PLUGINS to disable plugins

### DIFF
--- a/plugins/asciidoc.mk
+++ b/plugins/asciidoc.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring asciidoc,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: asciidoc asciidoc-guide asciidoc-manual install-asciidoc distclean-asciidoc
 
 MAN_INSTALL_PATH ?= /usr/local/share/man
@@ -44,3 +46,5 @@ distclean:: distclean-asciidoc
 
 distclean-asciidoc:
 	$(gen_verbose) rm -rf doc/html/ doc/guide.pdf doc/man3/ doc/man7/
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2014-2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring bootstrap,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: bootstrap bootstrap-lib bootstrap-rel new list-templates
 
 # Core targets.
@@ -397,3 +399,5 @@ endif
 
 list-templates:
 	$(verbose) echo Available templates: $(sort $(patsubst tpl_%,%,$(filter tpl_%,$(.VARIABLES))))
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/c_src.mk
+++ b/plugins/c_src.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2014-2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring c_src,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: clean-c_src distclean-c_src-env
 
 # Configuration.
@@ -117,3 +119,5 @@ distclean-c_src-env:
 
 -include $(C_SRC_ENV)
 endif
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/ci.mk
+++ b/plugins/ci.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring ci,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: ci ci-setup distclean-kerl
 
 KERL ?= $(CURDIR)/kerl
@@ -63,3 +65,5 @@ distclean:: distclean-kerl
 distclean-kerl:
 	$(gen_verbose) rm -rf $(KERL)
 endif
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/cover.mk
+++ b/plugins/cover.mk
@@ -1,6 +1,8 @@
 # Copyright 2015, Viktor Söderqvist <viktor@zuiderkwast.se>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring cover,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 COVER_REPORT_DIR = cover
 
 # Hook in coverage to ct
@@ -118,3 +120,5 @@ cover-report:
 
 endif
 endif # ifneq ($(COVER_REPORT_DIR),)
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/ct.mk
+++ b/plugins/ct.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2013-2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring ct,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: ct distclean-ct
 
 # Configuration.
@@ -53,3 +55,5 @@ $(foreach test,$(CT_SUITES),$(eval $(call ct_suite_target,$(test))))
 
 distclean-ct:
 	$(gen_verbose) rm -rf $(CURDIR)/logs/
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/dialyzer.mk
+++ b/plugins/dialyzer.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2013-2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring dialyzer,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: plt distclean-plt dialyze
 
 # Configuration.
@@ -41,3 +43,5 @@ else
 dialyze: $(DIALYZER_PLT)
 endif
 	$(verbose) dialyzer --no_native $(DIALYZER_DIRS) $(DIALYZER_OPTS)
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/edoc.mk
+++ b/plugins/edoc.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2013-2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring edoc,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: distclean-edoc edoc
 
 # Configuration.
@@ -20,3 +22,5 @@ edoc: doc-deps
 
 distclean-edoc:
 	$(gen_verbose) rm -f doc/*.css doc/*.html doc/*.png doc/edoc-info
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/elvis.mk
+++ b/plugins/elvis.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Erlang Solutions Ltd.
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring elvis,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: elvis distclean-elvis
 
 # Configuration.
@@ -37,3 +39,5 @@ elvis: $(ELVIS) $(ELVIS_CONFIG)
 
 distclean-elvis:
 	$(gen_verbose) rm -rf $(ELVIS)
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/erlydtl.mk
+++ b/plugins/erlydtl.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2013-2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring erlydtl,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 # Configuration.
 
 DTL_FULL_PATH ?= 0
@@ -37,3 +39,5 @@ ebin/$(PROJECT).app:: $(sort $(call core_find,$(DTL_PATH),*.dtl))
 	$(if $(strip $?),\
 		$(dtl_verbose) $(call erlang,$(call erlydtl_compile.erl,$?,-pa ebin/ $(DEPS_DIR)/erlydtl/ebin/)))
 endif
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/escript.mk
+++ b/plugins/escript.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2014 Dave Cottlehuber <dch@skunkwerks.at>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring escript,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: distclean-escript escript
 
 # Configuration.
@@ -62,3 +64,5 @@ escript:: distclean-escript deps app
 
 distclean-escript:
 	$(gen_verbose) rm -f $(ESCRIPT_NAME)
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/eunit.mk
+++ b/plugins/eunit.mk
@@ -2,6 +2,8 @@
 # Copyright (c) 2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is contributed to erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring eunit,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: eunit
 
 # Configuration
@@ -48,3 +50,5 @@ EUNIT_MODS = $(foreach mod,$(EUNIT_EBIN_MODS) $(filter-out \
 eunit: test-build
 	$(gen_verbose) $(ERL) -pa $(TEST_DIR) $(DEPS_DIR)/*/ebin ebin \
 		-eval "$(subst $(newline),,$(subst ",\",$(call eunit.erl,$(EUNIT_MODS))))"
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/protobuffs.mk
+++ b/plugins/protobuffs.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring protobuffs,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 # Verbosity.
 
 proto_verbose_0 = @echo " PROTO " $(filter %.proto,$(?F));
@@ -29,3 +31,5 @@ ifneq ($(wildcard src/),)
 ebin/$(PROJECT).app:: $(sort $(call core_find,src/,*.proto))
 	$(if $(strip $?),$(call compile_proto,$?))
 endif
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2013-2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring relx,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: relx-rel distclean-relx-rel distclean-relx run
 
 # Configuration.
@@ -69,3 +71,5 @@ help::
 		"  run         Compile the project, build the release and run it"
 
 endif
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/shell.mk
+++ b/plugins/shell.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2014, M Robert Martin <rob@version2beta.com>
 # This file is contributed to erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring shell,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: shell
 
 # Configuration.
@@ -26,3 +28,5 @@ build-shell-deps: $(ALL_SHELL_DEPS_DIRS)
 
 shell: build-shell-deps
 	$(gen_verbose) erl $(SHELL_PATH) $(SHELL_OPTS)
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/triq.mk
+++ b/plugins/triq.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring triq,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 ifeq ($(filter triq,$(DEPS) $(TEST_DEPS)),triq)
 .PHONY: triq
 
@@ -40,3 +42,5 @@ triq: test-build
 	$(gen_verbose) $(call erlang,$(call triq_check.erl,all,undefined,$(MODULES)))
 endif
 endif
+
+endif # ERLANG_MK_DISABLE_PLUGINS

--- a/plugins/xref.mk
+++ b/plugins/xref.mk
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Erlang Solutions Ltd.
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(findstring xref,$(ERLANG_MK_DISABLE_PLUGINS)),)
+
 .PHONY: xref distclean-xref
 
 # Configuration.
@@ -36,3 +38,5 @@ xref: deps app $(XREFR)
 
 distclean-xref:
 	$(gen_verbose) rm -rf $(XREFR)
+
+endif # ERLANG_MK_DISABLE_PLUGINS


### PR DESCRIPTION
For instance, one can disable the `ct` and `edoc` plugins by setting:
```
ERLANG_MK_DISABLE_PLUGINS = ct edoc
```