### PR TITLE
deps.mk: Do not remove $(DEPS_DIR) if $(SKIP_DEPS) is set

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -571,8 +571,12 @@ endef
 
 $(foreach dep,$(BUILD_DEPS) $(DEPS),$(eval $(call dep_target,$(dep))))
 
+ifneq ($(SKIP_DEPS),)
+distclean-deps: ; @echo -n
+else
 distclean-deps:
 	$(gen_verbose) rm -rf $(DEPS_DIR)
+endif
 
 # External plugins.
 


### PR DESCRIPTION
I suppose `$(SKIP_DEPS)` is here to let people download dependencies themselves. Therefore, `$(DEPS_DIR)` should not be removed when `make distclean` is called.