### PR TITLE
test/Makefile: Support non-GNU sed

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -770,7 +770,9 @@ core-app-no-makedep: build clean-core-app-no-makedep
 	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
 
 	$i "Set NO_MAKEDEP ?= 1 in the Makefile"
-	$t sed -i '2iNO_MAKEDEP ?= 1' $(APP)/Makefile
+	$t sed -i.bak '2i\
+NO_MAKEDEP ?= 1\
+' $(APP)/Makefile
 
 	$i "Generate .hrl files"
 	$t mkdir $(APP)/include/


### PR DESCRIPTION
This required two changes:

1. Modifying a file inplace using `-i` is not portable. GNU sed does not require an argument; the absence of it meaning it should change the file inplace. sed found on FreeBSD and probably other BSDs' require an argument, so inplace modification should be specified as:

  ```
sed -i ''
```

 Obviously, both -i are incompatible... The "solution" is to not do inplace modification.

2. The `[1addr]i` command takes its argument on the next line according to the standard (though, it's not explicitely stated, the syntax example suggests that). GNU sed accepts to have its argument on the same line as the command, but not FreeBSD's sed.