### PR TITLE
Add kjell support for make shell

### DIFF
--- a/plugins/shell.mk
+++ b/plugins/shell.mk
@@ -12,6 +12,7 @@ SHELL_KJELL ?=
 ifeq ($(SHELL_KJELL),1)
 SHELL_DEPS += kjell
 SHELL_ERL = $(DEPS_DIR)/kjell/bin/kjell
+SHELL_OPTS += -nouser
 else
 SHELL_ERL = erl
 endif

--- a/plugins/shell.mk
+++ b/plugins/shell.mk
@@ -7,6 +7,14 @@
 
 SHELL_PATH ?= -pa $(CURDIR)/ebin $(DEPS_DIR)/*/ebin
 SHELL_OPTS ?=
+SHELL_KJELL ?=
+
+ifeq ($(SHELL_KJELL),1)
+SHELL_DEPS += kjell
+SHELL_ERL = $(DEPS_DIR)/kjell/bin/kjell
+else
+SHELL_ERL = erl
+endif
 
 ALL_SHELL_DEPS_DIRS = $(addprefix $(DEPS_DIR)/,$(SHELL_DEPS))
 
@@ -25,4 +33,4 @@ build-shell-deps: $(ALL_SHELL_DEPS_DIRS)
 	$(verbose) for dep in $(ALL_SHELL_DEPS_DIRS) ; do $(MAKE) -C $$dep ; done
 
 shell: build-shell-deps
-	$(gen_verbose) erl $(SHELL_PATH) $(SHELL_OPTS)
+	$(gen_verbose) $(SHELL_ERL) $(SHELL_PATH) $(SHELL_OPTS)


### PR DESCRIPTION
This implements #242.

SHELL_KJELL=1 needs to be specified either through env var, Makefile
or argument.

kjell has some issues with sasl: https://github.com/karlll/kjell/issues/22. It's still not clear how to fix it in kjell but from the thread you can see that there's a workaround by adding `-nouser`. Should I append `-nouser` to `SHELL_OPTS` if `SHELL_KJELL` is enabled? Or provide another variable for user to control this fix? i.e: `SHELL_KJELL_NOUSER = 1` by default.