### PR TITLE
Make sure the ebin folder is in the search path

### DIFF
--- a/plugins/erlydtl.mk
+++ b/plugins/erlydtl.mk
@@ -16,6 +16,7 @@ dtl_verbose = $(dtl_verbose_$(V))
 
 define erlydtl_compile.erl
 	[begin
+		code:add_patha("ebin"),
 		Module0 = case $(DTL_FULL_PATH) of
 			0 ->
 				filename:basename(F, ".dtl");


### PR DESCRIPTION
Hi,

  I'm using a custom tag library in my app and found that erlang.mk wasn't handling this properly.
This patch makes sure that the ebin folder is added to the search path so that erlydtl can load things compiled by the app.

Daniel
