### PR TITLE
Do not try to execute an empty shell script in core-plugins-one test

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -348,7 +348,7 @@ ct: app1
 		"all() -> [testcase1]." \
 		"testcase1(_) -> 42 = m:succ(1)." \
 	 > app1/test/failing_SUITE.erl
-	$t if $(MAKE) -C app1 ct-failing $v ; then false ; fi
+	$t ! $(MAKE) -C app1 ct-failing $v
 	$i "Checking that '$(MAKE) distclean-ct' deletes logs."
 	$t $(MAKE) -C app1 distclean-ct $v
 	$t [ ! -e app1/logs ]
@@ -396,7 +396,7 @@ eunit: app1
 		"	?assertEqual(42, t:succ(1))." \
 		> app1/eunit/t_tests.erl
 	$t $(MAKE) -C app1 distclean TEST_DIR=eunit $v
-	$t if $(MAKE) -C app1 eunit TEST_DIR=eunit $v ; then false ; fi
+	$t ! $(MAKE) -C app1 eunit TEST_DIR=eunit $v
 	$t rm -rf app1/eunit app1/src/t.erl app1/test-eunit.log
 	$i "Test 'eunit' passed."
 

--- a/test/core_app.mk
+++ b/test/core_app.mk
@@ -300,7 +300,7 @@ core-app-error: build clean-core-app-error
 	$t echo "-module(girl)." > $(APP)/src/girl.erl
 
 	$i "Check that trying to build returns non-zero"
-	$t if $(MAKE) -C $(APP) $v; then false; fi
+	$t ! $(MAKE) -C $(APP) $v
 
 core-app-generate-erl: build clean-core-app-generate-erl
 

--- a/test/core_deps.mk
+++ b/test/core_deps.mk
@@ -121,7 +121,7 @@ core-deps-apps-conflict: build clean-core-deps-apps-conflict
 	$t $(MAKE) -C $(APP) new-lib in=cowlib $v
 
 	$i "Check that building the application fails because of a conflict"
-	$t if $(MAKE) -C $(APP) $v; then false; fi
+	$t ! $(MAKE) -C $(APP) $v
 
 	$i "Check that Cowlib wasn't fetched"
 	$t test ! -e $(APP)/deps/cowlib
@@ -140,7 +140,7 @@ core-deps-apps-deep-conflict: build clean-core-deps-apps-deep-conflict
 	$t $(MAKE) -C $(APP) new-lib in=cowlib $v
 
 	$i "Check that building the application fails because of a conflict"
-	$t if $(MAKE) -C $(APP) $v; then false; fi
+	$t ! $(MAKE) -C $(APP) $v
 
 	$i "Check that Cowlib wasn't fetched"
 	$t test ! -e $(APP)/deps/cowlib
@@ -658,7 +658,7 @@ core-deps-fetch-fail-bad: build clean-core-deps-fetch-fail-bad
 	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = cowlib\ndep_cowlib = oops https://github.com/ninenines/cowlib 1.0.0\n"}' $(APP)/Makefile
 
 	$i "Check that building the application fails"
-	$t if $(MAKE) -C $(APP) $v; then false; fi
+	$t ! $(MAKE) -C $(APP) $v
 
 core-deps-fetch-fail-unknown: build clean-core-deps-fetch-fail-unknown
 
@@ -671,7 +671,7 @@ core-deps-fetch-fail-unknown: build clean-core-deps-fetch-fail-unknown
 	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = unknown\n"}' $(APP)/Makefile
 
 	$i "Check that building the application fails"
-	$t if $(MAKE) -C $(APP) $v; then false; fi
+	$t ! $(MAKE) -C $(APP) $v
 
 core-deps-fetch-git: build clean-core-deps-fetch-git
 
@@ -776,7 +776,7 @@ core-deps-fetch-legacy: build clean-core-deps-fetch-legacy
 	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = cowlib\ndep_cowlib = https://github.com/ninenines/cowlib 1.0.0\n"}' $(APP)/Makefile
 
 	$i "Check that building the application fails"
-	$t if $(MAKE) -C $(APP) $v; then false; fi
+	$t ! $(MAKE) -C $(APP) $v
 
 	$i "Check that building the application works with IS_DEP=1"
 	$t $(MAKE) -C $(APP) IS_DEP=1 $v

--- a/test/core_plugins.mk
+++ b/test/core_plugins.mk
@@ -72,7 +72,7 @@ core-plugins-one: build clean-core-plugins-one
 	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = plugin_dep\ndep_plugin_dep = git file://$(abspath $(APP)/plugin_dep) master\nDEP_PLUGINS = plugin_dep/mk/plugin1.mk\n"}' $(APP)/Makefile
 
 	$i "Run 'make plugin1' and check that it prints plugin1"
-	$t test -n "`$(MAKE) -C $(APP) plugin1 | grep plugin1`"
+	$t $(MAKE) --no-print-directory -C $(APP) plugin1 | grep -qw plugin1
 
 	$i "Run 'make plugin2' and confirm the target doesn't exist"
-	$t if `$(MAKE) -C $(APP) plugin2`; then false; fi
+	$t ! $(MAKE) --no-print-directory -C $(APP) plugin2

--- a/test/core_upgrade.mk
+++ b/test/core_upgrade.mk
@@ -34,7 +34,7 @@ core-upgrade-custom-build-dir: build clean-core-upgrade-custom-build-dir
 	$t ERLANG_MK_BUILD_DIR=custom $(MAKE) -C $(APP) erlang-mk $v
 
 	$i "Check that the rule is gone"
-	$t if $(MAKE) -C $(APP) erlang_mk_upgrade_test_rule $v; then false; fi
+	$t ! $(MAKE) -C $(APP) erlang_mk_upgrade_test_rule $v
 
 	$i "Check that the custom build directory is gone"
 	$t test ! -d $(APP)/custom/
@@ -53,7 +53,7 @@ core-upgrade-custom-config: build clean-core-upgrade-custom-config
 	$t $(MAKE) -C $(APP) erlang-mk $v
 
 	$i "Check that the bootstrap plugin is gone"
-	$t if $(MAKE) -C $(APP) list-templates $v; then false; fi
+	$t ! $(MAKE) -C $(APP) list-templates $v
 
 core-upgrade-custom-repo: build clean-core-upgrade-custom-repo
 
@@ -97,7 +97,7 @@ core-upgrade-no-config: build clean-core-upgrade-no-config
 	$t $(MAKE) -C $(APP) erlang-mk $v
 
 	$i "Check that the rule is gone"
-	$t if $(MAKE) -C $(APP) erlang_mk_upgrade_test_rule $v; then false; fi
+	$t ! $(MAKE) -C $(APP) erlang_mk_upgrade_test_rule $v
 
 core-upgrade-renamed-config: build clean-core-upgrade-renamed-config
 
@@ -116,4 +116,4 @@ core-upgrade-renamed-config: build clean-core-upgrade-renamed-config
 	$t $(MAKE) -C $(APP) erlang-mk $v
 
 	$i "Check that the bootstrap plugin is gone"
-	$t if $(MAKE) -C $(APP) list-templates $v; then false; fi
+	$t ! $(MAKE) -C $(APP) list-templates $v


### PR DESCRIPTION
The previous code did:
```sh
if `<code that prints nothing on stdout>`; then ...
```

So the test failed but not for the good reason. The forked shell printed:
```
/bin/sh: gmake[2]:: not found
```

Now, both `"Run 'make ...'"` tests are simplified and do not rely on backticks and test(1) anymore. Either the output is inspected or the exit code is checked.