### PR TITLE
erlc.mk: Handle .app generation outside of .erl compilation

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -197,12 +197,14 @@ endef
 
 ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES)
 	$(if $(strip $?),$(call compile_erl,$?))
+
+ebin/$(PROJECT).app::
 	$(eval GITDESCRIBE := $(shell git describe --dirty --abbrev=7 --tags --always --first-parent 2>/dev/null || true))
 	$(eval MODULES := $(patsubst %,'%',$(sort $(notdir $(basename \
 		$(filter-out $(ERLC_EXCLUDE_PATHS),$(ERL_FILES) $(CORE_FILES) $(BEAM_FILES)))))))
 ifeq ($(wildcard src/$(PROJECT).app.src),)
 	$(app_verbose) printf "$(subst $(newline),\n,$(subst ",\",$(call app_file,$(GITDESCRIBE),$(MODULES))))" \
-		> ebin/$(PROJECT).app
+		> $@
 else
 	$(verbose) if [ -z "$$(grep -E '^[^%]*{\s*modules\s*,' src/$(PROJECT).app.src)" ]; then \
 		echo "Empty modules entry not found in $(PROJECT).app.src. Please consult the erlang.mk README for instructions." >&2; \
@@ -211,7 +213,7 @@ else
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed "s/{[[:space:]]*modules[[:space:]]*,[[:space:]]*\[\]}/{modules, \[$(call comma_list,$(MODULES))\]}/" \
 		| sed "s/{id,[[:space:]]*\"git\"}/{id, \"$(GITDESCRIBE)\"}/" \
-		> ebin/$(PROJECT).app
+		> $@
 endif
 
 clean:: clean-app


### PR DESCRIPTION
Previously, if no source file were changed, the `ebin/$(PROJECT).app` rule was not evaluated again. Therefore, the `.app` file was not updated, even though, `$(GITDESCRIBE)` or `.app.src` was changed.

Now, the .app file is handled separately and always evaluated. Before overwriting the existing `.app` file though, we check if the content of the new file is different.

In the testsuite, the `.app` file is now unmodified.