### PR TITLE
fix multiple patterns used on core_find

### DIFF
--- a/plugins/c_src.mk
+++ b/plugins/c_src.mk
@@ -60,7 +60,7 @@ clean::
 else
 
 ifeq ($(SOURCES),)
-SOURCES := $(sort $(call core_find,$(C_SRC_DIR)/,*.c *.C *.cc *.cpp))
+SOURCES := $(sort $(foreach pat,*.c *.C *.cc *.cpp,$(call core_find,$(C_SRC_DIR)/,$(pat))))
 endif
 OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
 


### PR DESCRIPTION
`find`, the underlying command of `core_find`, [does not support multiple patterns
after -name](http://stackoverflow.com/questions/1133698/find-name-pattern-that-matches-multiple-patterns).  This patch fixes multi-pattern use in `c_src.mk` by calling `core_find`
once for each pattern.