### PR TITLE
Fix core-app-pt-erlc-opts so the dependency is built

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -21,7 +21,7 @@ export DEPS_DIR
 REBAR_DEPS_DIR = $(DEPS_DIR)
 export REBAR_DEPS_DIR
 
-dep_name = $(if $(dep_$(1)),$(1),$(pkg_$(1)_name))
+dep_name = $(if $(dep_$(1)),$(1),$(if $(pkg_$(1)_name),$(pkg_$(1)_name),$(1)))
 dep_repo = $(patsubst git://github.com/%,https://github.com/%, \
 	$(if $(dep_$(1)),$(word 2,$(dep_$(1))),$(pkg_$(1)_repo)))
 dep_commit = $(if $(dep_$(1)_commit),$(dep_$(1)_commit),$(if $(dep_$(1)),$(word 3,$(dep_$(1))),$(pkg_$(1)_commit)))


### PR DESCRIPTION
The generated Makefile said:
```
PROJECT = core_app_pt_erlc_opts
BUILD_DEPS = my_pt_dep
...
```

However, in `core/deps.mk`, the variable `$(ALL_DEPS_DIRS)` calls `$(dep_name)` to get the name of the dependency, and `$(dep_name)` checks the value of either `$(dep_something)` or
`$(pkg_something_name)`. In this test case, none was set, leading to `$(ALL_DEPS_DIRS)` being empty and no dependency was built.

Adding `dep_my_pt_dep = null` to the generated Makefile is enough, though the fetch method is obviously incorrect. The generated Makefile now looks like:
```make
PROJECT = core_app_pt_erlc_opts
BUILD_DEPS = my_pt_dep
dep_my_pt_dep = null
...
```