### PR TITLE
Use `:` as a noop instead of `echo -n`

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -82,7 +82,7 @@ all:: deps app rel
 
 # Noop to avoid a Make warning when there's nothing to do.
 rel::
-	$(verbose) echo -n
+	$(verbose) :
 
 check:: clean app tests
 

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -62,7 +62,7 @@ endif
 	$(verbose) mkdir -p $(ERLANG_MK_TMP)
 	$(verbose) for dep in $(ALL_DEPS_DIRS) ; do \
 		if grep -qs ^$$dep$$ $(ERLANG_MK_TMP)/deps.log; then \
-			echo -n; \
+			:; \
 		else \
 			echo $$dep >> $(ERLANG_MK_TMP)/deps.log; \
 			if [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ]; then \
@@ -127,7 +127,7 @@ define dep_autopatch_erlang_mk
 endef
 else
 define dep_autopatch_erlang_mk
-	echo -n
+	:
 endef
 endif
 

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -78,7 +78,7 @@ endef
 endif
 
 app-build: ebin/$(PROJECT).app
-	$(verbose) echo -n
+	$(verbose) :
 
 # Source files.
 


### PR DESCRIPTION
The `-n` flag is not standard and not portable. It is supported by many Bourne shell to suppress the trailing newline character. But some old shells do not support this and "-n" is printed.

This is the case for instance on some old versions of Mac OS X where `/bin/sh` is Bash 3.2.