### PR TITLE
Fix Erlydtl, add DTL_OPTS

### DIFF
--- a/plugins/erlydtl.mk
+++ b/plugins/erlydtl.mk
@@ -4,6 +4,7 @@
 # Configuration.
 
 DTL_FULL_PATH ?=
+DTL_OPTS ?= []
 DTL_PATH ?= templates/
 DTL_SUFFIX ?= _dtl
 
@@ -24,7 +25,7 @@ define erlydtl_compile.erl
 				re:replace(F2, "/",  "_",  [{return, list}, global])
 		end,
 		Module = list_to_atom(string:to_lower(Module0) ++ "$(DTL_SUFFIX)"),
-		case erlydtl:compile(F, Module, [{out_dir, "ebin/"}, return_errors, {doc_root, "templates"}]) of
+		case erlydtl:compile(F, Module, $(DTL_OPTS) ++ [{out_dir, "ebin/"}, return_errors, {doc_root, "templates"}]) of
 			ok -> ok;
 			{ok, _} -> ok
 		end
@@ -48,5 +49,5 @@ $(DTL_FILES): $(MAKEFILE_LIST)
 
 ebin/$(PROJECT).app:: $(DTL_FILES)
 	$(if $(strip $?),\
-		$(dtl_verbose) $(call erlang,$(call erlydtl_compile.erl,$?,-pa ebin/ $(DEPS_DIR)/erlydtl/ebin/)))
+		$(dtl_verbose) $(call erlang,$(call erlydtl_compile.erl,$?),-pa ebin/ $(DEPS_DIR)/erlydtl/ebin/))
 endif


### PR DESCRIPTION
There was a misplaced ) which resulted that erl didn't get ebin as -pa parameter. So my custom filter was never picked up.
I added DTL_OPTS in order that one can add

```
[{libraries, [{mylib, mylib_module}]}, {default_libraries, [mylib]}]
```

easily.