### PR TITLE
make erlang-mk: Copy build.config after switching to $(ERLANG_MK_COMMIT)

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -192,8 +192,11 @@ ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
 erlang-mk:
 	git clone $(ERLANG_MK_REPO) $(ERLANG_MK_BUILD_DIR)
+ifdef ERLANG_MK_COMMIT
+	cd $(ERLANG_MK_BUILD_DIR) && git checkout $(ERLANG_MK_COMMIT)
+endif
 	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR)/build.config; fi
-	cd $(ERLANG_MK_BUILD_DIR) && $(if $(ERLANG_MK_COMMIT),git checkout $(ERLANG_MK_COMMIT) &&) $(MAKE)
+	$(MAKE) -C $(ERLANG_MK_BUILD_DIR)
 	cp $(ERLANG_MK_BUILD_DIR)/erlang.mk ./erlang.mk
 	rm -rf $(ERLANG_MK_BUILD_DIR)
 


### PR DESCRIPTION
If the local build.config has changes compared to upstream's master branch, and `$(ERLANG_MK_COMMIT)` also brings changes to this file, copying the local file to the checkout before switching to `$(ERLANG_MK_COMMIT)` caused git-checkout(1) to abort with:

```
error: Your local changes to the following files would be overwritten by checkout:
	build.config
Please, commit your changes or stash them before you can switch branches.
Aborting
```