### PR TITLE
Do not export templates as environment variables

### DIFF
--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -344,7 +344,7 @@ endef
 # Plugin-specific targets.
 
 define render_template
-	$(verbose) echo "$${_$(1)}" > $(2)
+	$(verbose) printf -- '$(subst $(newline),\n,$(subst %,%%,$(subst ','\'',$(subst $(tab),$(WS),$(call $(1))))))\n' > $(2)
 endef
 
 ifndef WS
@@ -354,10 +354,6 @@ else
 WS = $(tab)
 endif
 endif
-
-$(foreach template,$(filter bs_% tpl_%,$(.VARIABLES)), \
-	$(eval _$(template) = $$(subst $$(tab),$$(WS),$$($(template)))) \
-	$(eval export _$(template)))
 
 bootstrap:
 ifneq ($(wildcard src/),)

--- a/plugins/c_src.mk
+++ b/plugins/c_src.mk
@@ -192,10 +192,6 @@ hello(_) ->
 	erlang:nif_error({not_loaded, ?MODULE}).
 endef
 
-$(foreach template,bs_c_nif bs_erl_nif, \
-	$(eval _$(template) = $$(subst $$(tab),$$(WS),$$($(template)))) \
-	$(eval export _$(template)))
-
 new-nif:
 ifneq ($(wildcard $(C_SRC_DIR)/$n.c),)
 	$(error Error: $(C_SRC_DIR)/$n.c already exists)


### PR DESCRIPTION
Use `$(file)` macro to write the generated files. This avoids environment pollution with a large amount of Erlang code.