### PR TITLE
Improve the customisation of edoc, with default values

### DIFF
--- a/plugins/edoc.mk
+++ b/plugins/edoc.mk
@@ -11,7 +11,9 @@ EDOC_SRC_DIRS ?= $(ALL_APPS_DIRS) $(ALL_DEPS_DIRS)
 # TODO: use double-quote instead of single + atom_to_list
 #       The problem is in correctly escaping double-quotes
 define edoc.erl
-	SrcPaths = [ atom_to_list(P) || P <- [$(call comma_list,$(patsubst %,'%',$(EDOC_SRC_DIRS)))] ],
+	SrcPaths = lists:foldl(fun (P, Acc) ->
+	                         filelib:wildcard(atom_to_list(P) ++ "/{src,c_src}") ++ Acc
+	                       end, [], [$(call comma_list,$(patsubst %,'%',$(EDOC_SRC_DIRS)))]),
 	DefaultOpts = [ {source_path, SrcPaths}
 	               ,{subpackages, false} ],
 	edoc:application($(1), ".", [$(2)] ++ DefaultOpts),

--- a/plugins/edoc.mk
+++ b/plugins/edoc.mk
@@ -6,19 +6,27 @@
 # Configuration.
 
 EDOC_OPTS ?=
+EDOC_SRC_DIRS ?= $(ALL_APPS_DIRS) $(ALL_DEPS_DIRS)
+
+# TODO: use double-quote instead of single + atom_to_list
+#       The problem is in correctly escaping double-quotes
+define edoc.erl
+	SrcPaths = [ atom_to_list(P) || P <- [$(call comma_list,$(patsubst %,'%',$(EDOC_SRC_DIRS)))] ],
+	DefaultOpts = [ {source_path, SrcPaths}
+	               ,{subpackages, false} ],
+	edoc:application($(1), ".", [$(2)] ++ DefaultOpts),
+	halt(0).
+endef
 
 # Core targets.
-
-ifneq ($(wildcard doc/overview.edoc),)
-docs:: edoc
-endif
+docs:: distclean-edoc edoc
 
 distclean:: distclean-edoc
 
 # Plugin-specific targets.
 
-edoc: distclean-edoc doc-deps
-	$(gen_verbose) $(ERL) -eval 'edoc:application($(PROJECT), ".", [$(EDOC_OPTS)]), halt().'
+edoc: doc-deps
+	$(gen_verbose) $(call erlang,$(call edoc.erl,$(PROJECT),$(EDOC_OPTS)))
 
 distclean-edoc:
 	$(gen_verbose) rm -f doc/*.css doc/*.html doc/*.png doc/edoc-info


### PR DESCRIPTION
edoc options are set through:
- default values (proplists): 
  - {subpackages, false}
  - {source_path, ALL_APPS_DIRS + ALL_DEPS_DIRS}
- 'source_path' can be overriden with EDOC_SRC_DIRS
- all options can be overriden with EDOC_OPTS
