### PR TITLE
Fix .app compilation when a git tag contains a '/'

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -250,7 +250,7 @@ else
 	fi
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed "s/{[[:space:]]*modules[[:space:]]*,[[:space:]]*\[\]}/{modules, \[$(call comma_list,$(MODULES))\]}/" \
-		| sed "s/{id,[[:space:]]*\"git\"}/{id, \"$(GITDESCRIBE)\"}/" \
+		| sed "s/{id,[[:space:]]*\"git\"}/{id, \"$(subst /,\/,$(GITDESCRIBE))\"}/" \
 		> ebin/$(PROJECT).app
 endif
 


### PR DESCRIPTION
When the last git tag contains '/' character, compilation of .app file fails because it interfers with sed regexp syntax