### PR TITLE
Remove spaces after commas globally

### DIFF
--- a/core/compat.mk
+++ b/core/compat.mk
@@ -6,7 +6,7 @@
 # We strip out -Werror because we don't want to fail due to
 # warnings when used as a dependency.
 
-compat_prepare_erlc_opts = $(shell echo "$1" | sed 's/, */,/')
+compat_prepare_erlc_opts = $(shell echo "$1" | sed 's/, */,/g')
 
 define compat_convert_erlc_opts
 $(if $(filter-out -Werror,$1),\

--- a/test/core_compat.mk
+++ b/test/core_compat.mk
@@ -220,7 +220,7 @@ core-compat-rebar-pt: build clean
 	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = lager\n"}' $(APP)/Makefile
 
 	$i "Add the lager_transform parse_transform to ERLC_OPTS"
-	$t echo "ERLC_OPTS += +'{parse_transform, lager_transform}'" >> $(APP)/Makefile
+	$t echo "ERLC_OPTS += +'{parse_transform, lager_transform}' +'{lager_truncation_size, 1234}'" >> $(APP)/Makefile
 
 	$i "Build the application"
 	$t $(MAKE) -C $(APP) $v
@@ -236,6 +236,7 @@ core-compat-rebar-pt: build clean
 		{ok, C} = file:consult(\"$(APP)/rebar.config\"), \
 		{_, Opts} = lists:keyfind(erl_opts, 1, C), \
 		true = lists:member({parse_transform, lager_transform}, Opts), \
+		true = lists:member({lager_truncation_size, 1234}, Opts), \
 		halt()"
 
 # For the new build method, we have to simulate keeping the .app file


### PR DESCRIPTION
When preparing erlc_opts, remove all comma/whitespace pairs instead of
just the first