### PR TITLE
Create ebin directory if it doesn't exist before erlydtl compile.

### DIFF
--- a/plugins/erlydtl.mk
+++ b/plugins/erlydtl.mk
@@ -38,6 +38,11 @@ define erlydtl_compile.erl
 				re:replace(F2, "/",  "_",  [{return, list}, global])
 		end,
 		Module = list_to_atom(string:to_lower(Module0) ++ "$(DTL_SUFFIX)"),
+		case file:make_dir("ebin/") of
+			ok -> ok;
+			{error, eexist} -> ok;
+			{error, Other}  -> throw({error, {unable_to_create_ebin_dir, Other}})
+		end,
 		case erlydtl:compile(F, Module, [{out_dir, "ebin/"}, return_errors, {doc_root, "templates"}]) of
 			ok -> ok;
 			{ok, _} -> ok


### PR DESCRIPTION
Maybe there are better way to do so. In some make task ordering? Or make erlang compile phase run before erlydtl.