### PR TITLE
Fix ct for multi-app repositories

### DIFF
--- a/plugins/ct.mk
+++ b/plugins/ct.mk
@@ -31,7 +31,7 @@ help::
 CT_RUN = ct_run \
 	-no_auto_compile \
 	-noinput \
-	-pa $(CURDIR)/ebin $(DEPS_DIR)/*/ebin $(TEST_DIR) \
+	-pa $(CURDIR)/ebin $(DEPS_DIR)/*/ebin $(APPS_DIR)/*/ebin $(TEST_DIR) \
 	-dir $(TEST_DIR) \
 	-logdir $(CURDIR)/logs
 
@@ -51,7 +51,7 @@ endef
 
 $(foreach app,$(ALL_APPS_DIRS),$(eval $(call ct_app_target,$(app))))
 
-apps-ct: $(addprefix apps-ct-,$(ALL_APPS_DIRS))
+apps-ct: test-build $(addprefix apps-ct-,$(ALL_APPS_DIRS))
 endif
 
 ifndef t

--- a/test/plugin_ct.mk
+++ b/test/plugin_ct.mk
@@ -63,6 +63,12 @@ ct-apps-only: build clean
 	$i "Create a new library named my_lib"
 	$t $(MAKE) -C $(APP) new-lib in=my_lib $v
 
+	$i "Populate my_lib"
+	$t printf "%s\n" \
+		"-module(my_lib)." \
+		"-export([random_int/0])." \
+		"random_int() -> 4." > $(APP)/apps/my_lib/src/my_lib.erl
+
 	$i "Check that Common Test detects no tests"
 	$t $(MAKE) -C $(APP) ct | grep -q "Nothing to be done for 'ct'."
 
@@ -70,9 +76,10 @@ ct-apps-only: build clean
 	$t mkdir $(APP)/apps/my_app/test
 	$t printf "%s\n" \
 		"-module(my_app_SUITE)." \
-		"-export([all/0, ok/1])." \
-		"all() -> [ok]." \
-		"ok(_) -> ok." > $(APP)/apps/my_app/test/my_app_SUITE.erl
+		"-export([all/0, ok/1, call_my_lib/1])." \
+		"all() -> [ok, call_my_lib]." \
+		"ok(_) -> ok." \
+		"call_my_lib(_) -> 4 = my_lib:random_int()." > $(APP)/apps/my_app/test/my_app_SUITE.erl
 
 	$i "Generate a Common Test suite in my_lib"
 	$t mkdir $(APP)/apps/my_lib/test


### PR DESCRIPTION
* Include $(APPS_DIR)/*/ebin in CT_RUN
* test-build before ct-apps
* Test that my_lib is accessible from my-app ct

Currently ct is not really working for multi-application repositories. This PR addresses and fixes the issue though further restructuring of the CT plugin might be advisable in the future.

Local test run failed on dialyzer tests that I think are unrelated.