### PR TITLE
Add empty 'module' template

### DIFF
--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -172,6 +172,11 @@ code_change(_OldVsn, State, _Extra) ->
 	{ok, State}.
 endef
 
+define tpl_module
+-module($(n)).
+-export([]).
+endef
+
 define tpl_cowboy_http
 -module($(n)).
 -behaviour(cowboy_http_handler).

--- a/test/plugin_bootstrap.mk
+++ b/test/plugin_bootstrap.mk
@@ -190,6 +190,7 @@ bootstrap-templates: build clean
 	$t $(MAKE) -C $(APP) --no-print-directory new t=cowboy_rest n=my_rest
 	$t $(MAKE) -C $(APP) --no-print-directory new t=cowboy_ws n=my_ws
 	$t $(MAKE) -C $(APP) --no-print-directory new t=ranch_protocol n=my_protocol
+	$t $(MAKE) -C $(APP) --no-print-directory new t=module n=my_module
 
 # Here we disable warnings because templates contain missing behaviors.
 	$i "Build the application"
@@ -200,11 +201,12 @@ bootstrap-templates: build clean
 	$t test -f $(APP)/ebin/my_fsm.beam
 	$t test -f $(APP)/ebin/my_server.beam
 	$t test -f $(APP)/ebin/my_sup.beam
+	$t test -f $(APP)/ebin/my_module.beam
 
 	$i "Check that all the modules can be loaded"
 	$t $(ERL) -pa $(APP)/ebin/ -eval " \
 		ok = application:start($(APP)), \
-		{ok, Mods = [my_fsm, my_http, my_loop, my_protocol, my_rest, my_server, my_sup, my_ws]} \
+		{ok, Mods = [my_fsm, my_http, my_loop, my_module, my_protocol, my_rest, my_server, my_sup, my_ws]} \
 			= application:get_key($(APP), modules), \
 		[{module, M} = code:load_file(M) || M <- Mods], \
 		halt()"


### PR DESCRIPTION
Every .erl source file will need at least a -module and a single -export
definition. With the empty template a file can be quickly created that
already populates -module with the right value as well as an empty
export field that can quickly be filled.