### PR TITLE
Do not use grep Extended Mode

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -244,7 +244,7 @@ ifeq ($(wildcard src/$(PROJECT).app.src),)
 	$(app_verbose) printf "$(subst $(newline),\n,$(subst ",\",$(call app_file,$(GITDESCRIBE),$(MODULES))))" \
 		> ebin/$(PROJECT).app
 else
-	$(verbose) if [ -z "$$(grep -E '^[^%]*{\s*modules\s*,' src/$(PROJECT).app.src)" ]; then \
+	$(verbose) if [ -z "$$(grep -e '^[^%]*{\s*modules\s*,' src/$(PROJECT).app.src)" ]; then \
 		echo "Empty modules entry not found in $(PROJECT).app.src. Please consult the erlang.mk README for instructions." >&2; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Extended Mode uses { and } as special characters. Making grep
implementations other then GNU grep fail (see
http://www.gnu.org/software/grep/manual/grep.html#Basic-vs-Extended).

---

I assume -E is a typo for -e as Extended Mode is not needed for that grep.
Resolves #523.