### PR TITLE
add WITHOUT variable to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,16 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+WITHOUT ?=
+
 BUILD_CONFIG_FILE ?= $(CURDIR)/build.config
+ifeq ($(WITHOUT),)
 BUILD_CONFIG = $(shell sed "s/\#.*//" $(BUILD_CONFIG_FILE))
+else
+empty := $(subst ,, )
+BUILD_EXCLUDE = "^$(subst $(empty),\|^,$(WITHOUT))"
+BUILD_CONFIG = $(shell sed "s/\#.*//" $(BUILD_CONFIG_FILE)|grep -v $(BUILD_EXCLUDE))
+endif
 
 ERLANG_MK = erlang.mk
 ERLANG_MK_VERSION = $(shell git describe --tags --dirty)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ERLANG_MK_VERSION = $(shell git describe --tags --dirty)
 all:
 	awk 'FNR==1 && NR!=1{print ""}1' $(patsubst %,%.mk,$(BUILD_CONFIG)) \
 		| sed 's/^ERLANG_MK_VERSION = .*/ERLANG_MK_VERSION = $(ERLANG_MK_VERSION)/' \
-		| sed 's/^DEFAULT_WITHOUT = .*/DEFAULT_WITHOUT = $(WITHOUT)/' > $(ERLANG_MK)
+		| sed 's:^DEFAULT_WITHOUT = .*:DEFAULT_WITHOUT = $(WITHOUT):' > $(ERLANG_MK)
 
 ifdef p
 # Remove p from the list of variables since that conflicts with bootstrapping.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ERLANG_MK_VERSION = $(shell git describe --tags --dirty)
 all:
 	awk 'FNR==1 && NR!=1{print ""}1' $(patsubst %,%.mk,$(BUILD_CONFIG)) \
 		| sed 's/^ERLANG_MK_VERSION = .*/ERLANG_MK_VERSION = $(ERLANG_MK_VERSION)/' \
-		| sed 's:^DEFAULT_WITHOUT = .*:DEFAULT_WITHOUT = $(WITHOUT):' > $(ERLANG_MK)
+		| sed 's:^ERLANG_MK_WITHOUT = .*:ERLANG_MK_WITHOUT = $(WITHOUT):' > $(ERLANG_MK)
 
 ifdef p
 # Remove p from the list of variables since that conflicts with bootstrapping.

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ ERLANG_MK_VERSION = $(shell git describe --tags --dirty)
 
 all:
 	awk 'FNR==1 && NR!=1{print ""}1' $(patsubst %,%.mk,$(BUILD_CONFIG)) \
-		| sed 's/^ERLANG_MK_VERSION = .*/ERLANG_MK_VERSION = $(ERLANG_MK_VERSION)/' > $(ERLANG_MK)
+		| sed 's/^ERLANG_MK_VERSION = .*/ERLANG_MK_VERSION = $(ERLANG_MK_VERSION)/' \
+		| sed 's/^DEFAULT_WITHOUT = .*/DEFAULT_WITHOUT = $(WITHOUT)/' > $(ERLANG_MK)
 
 ifdef p
 # Remove p from the list of variables since that conflicts with bootstrapping.

--- a/core/core.mk
+++ b/core/core.mk
@@ -194,6 +194,7 @@ ERLANG_MK_BUILD_CONFIG ?= build.config
 ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
 WITHOUT ?= $(DEFAULT_WITHOUT)
+WITHOUT := $(strip $(WITHOUT))
 
 erlang-mk:
 	git clone $(ERLANG_MK_REPO) $(ERLANG_MK_BUILD_DIR)
@@ -201,7 +202,7 @@ ifdef ERLANG_MK_COMMIT
 	cd $(ERLANG_MK_BUILD_DIR) && git checkout $(ERLANG_MK_COMMIT)
 endif
 	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR)/build.config; fi
-	$(MAKE) -C $(ERLANG_MK_BUILD_DIR) WITHOUT="$(WITHOUT)"
+	$(MAKE) -C $(ERLANG_MK_BUILD_DIR) WITHOUT='$(WITHOUT)'
 	cp $(ERLANG_MK_BUILD_DIR)/erlang.mk ./erlang.mk
 	rm -rf $(ERLANG_MK_BUILD_DIR)
 

--- a/core/core.mk
+++ b/core/core.mk
@@ -18,6 +18,9 @@ ERLANG_MK_FILENAME := $(realpath $(lastword $(MAKEFILE_LIST)))
 
 ERLANG_MK_VERSION = 1
 
+# Plugins ignored
+DEFAULT_WITHOUT = ""
+
 # Core configuration.
 
 PROJECT ?= $(notdir $(CURDIR))
@@ -190,13 +193,15 @@ ERLANG_MK_COMMIT ?=
 ERLANG_MK_BUILD_CONFIG ?= build.config
 ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
+WITHOUT ?= $(DEFAULT_WITHOUT)
+
 erlang-mk:
 	git clone $(ERLANG_MK_REPO) $(ERLANG_MK_BUILD_DIR)
 ifdef ERLANG_MK_COMMIT
 	cd $(ERLANG_MK_BUILD_DIR) && git checkout $(ERLANG_MK_COMMIT)
 endif
 	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR)/build.config; fi
-	$(MAKE) -C $(ERLANG_MK_BUILD_DIR)
+	$(MAKE) -C $(ERLANG_MK_BUILD_DIR) WITHOUT="$(WITHOUT)"
 	cp $(ERLANG_MK_BUILD_DIR)/erlang.mk ./erlang.mk
 	rm -rf $(ERLANG_MK_BUILD_DIR)
 

--- a/core/core.mk
+++ b/core/core.mk
@@ -19,7 +19,7 @@ ERLANG_MK_FILENAME := $(realpath $(lastword $(MAKEFILE_LIST)))
 ERLANG_MK_VERSION = 1
 
 # Plugins ignored
-DEFAULT_WITHOUT = ""
+ERLANG_MK_WITHOUT = ""
 
 # Core configuration.
 
@@ -193,7 +193,7 @@ ERLANG_MK_COMMIT ?=
 ERLANG_MK_BUILD_CONFIG ?= build.config
 ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
-WITHOUT ?= $(DEFAULT_WITHOUT)
+WITHOUT ?= $(ERLANG_MK_WITHOUT)
 WITHOUT := $(strip $(WITHOUT))
 
 erlang-mk:

--- a/core/core.mk
+++ b/core/core.mk
@@ -18,7 +18,7 @@ ERLANG_MK_FILENAME := $(realpath $(lastword $(MAKEFILE_LIST)))
 
 ERLANG_MK_VERSION = 1
 
-# Plugins ignored
+# Ignored plugins
 ERLANG_MK_WITHOUT = ""
 
 # Core configuration.

--- a/doc/src/guide/getting_started.asciidoc
+++ b/doc/src/guide/getting_started.asciidoc
@@ -78,6 +78,17 @@ to bootstrap. This operation is done only once. Consult the
 xref:updating[Updating Erlang.mk] chapter for more
 information.
 
+[NOTE]
+----
+By default the file contains a package index. To filter it, run the command
+above with the `WITHOUT=index` argument.
+
+[source,bash]
+$ make -f erlang.mk bootstrap WITHOUT=index
+
+This command will generate the file without the index.
+----
+
 Of course, the generated project can now be compiled:
 
 [source,bash]

--- a/doc/src/guide/updating.asciidoc
+++ b/doc/src/guide/updating.asciidoc
@@ -62,7 +62,7 @@ by modifying the value for `ERLANG_MK_BUILD_CONFIG`. You can also
 tell Erlang.mk to use a different temporary directory by changing
 the `ERLANG_MK_BUILD_DIR` variable.
 
-Alternatively you can filter a plugin in the build config by using the
+Alternatively you can filter out a plugin in the build config by using the
 `WITHOUT` variable the first time you generate the file. For example this
 commande will filter the index plugin:
 

--- a/doc/src/guide/updating.asciidoc
+++ b/doc/src/guide/updating.asciidoc
@@ -61,3 +61,10 @@ You can also name the file differently or put it in a separate folder
 by modifying the value for `ERLANG_MK_BUILD_CONFIG`. You can also
 tell Erlang.mk to use a different temporary directory by changing
 the `ERLANG_MK_BUILD_DIR` variable.
+
+Alternatively you can filter a plugin in the build config by using the
+`WITHOUT` variable the first time you generate the file. For example this
+commande will filter the index plugin:
+
+[source,bash]
+$ make -f erlang.mk WITHOUT=index


### PR DESCRIPTION
This allows to ignore lines from the default build.config if needed.
For example to not include packages run make WITHOUT=index

fix #537
