### PR TITLE
Allow APPS_DIR apps to include_lib each other's headers

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -53,6 +53,9 @@ deps::
 else
 deps:: $(ALL_DEPS_DIRS)
 ifndef IS_APP
+	for dep in $(ALL_APPS_DIRS) ; do \
+		mkdir -p $$dep/ebin; \
+	done
 	$(verbose) for dep in $(ALL_APPS_DIRS) ; do \
 		$(MAKE) -C $$dep IS_APP=1 || exit $$?; \
 	done


### PR DESCRIPTION
This is a fix for #447 and possibly a partial fix for #380.

In summary, apps in `APPS_DIR` cannot reliably `include_lib` each other's headers.  This PR fixes that.