### PR TITLE
Add Rust plugin and helper library to index

### DIFF
--- a/doc/src/guide/external_plugins_list.asciidoc
+++ b/doc/src/guide/external_plugins_list.asciidoc
@@ -51,3 +51,8 @@ http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html[Mix].
 === reload.mk
 
 A https://github.com/bullno1/reload.mk[live reload plugin] for Erlang.mk.
+
+=== rust.mk
+
+A https://github.com/goertzenator/rust.mk[plugin] to build https://www.rust-lang.org/[Rust] crates and install binaries into `priv/`.  
+

--- a/index/find_crate.mk
+++ b/index/find_crate.mk
@@ -1,0 +1,7 @@
+PACKAGES += find_crate
+pkg_find_crate_name = find_crate
+pkg_find_crate_description = Find Rust libs and exes in Erlang application priv directory
+pkg_find_crate_homepage = https://github.com/goertzenator/find_crate
+pkg_find_crate_fetch = git
+pkg_find_crate_repo = https://github.com/goertzenator/find_crate
+pkg_find_crate_commit = master

--- a/index/rust.mk
+++ b/index/rust.mk
@@ -1,0 +1,7 @@
+PACKAGES += rust
+pkg_rust_name = rust
+pkg_rust_description = Build Rust crates in an Erlang application
+pkg_rust_homepage = https://github.com/goertzenator/rust.mk
+pkg_rust_fetch = git
+pkg_rust_repo = https://github.com/goertzenator/rust.mk
+pkg_rust_commit = master


### PR DESCRIPTION
This is a plugin and helper library to build Rust ports/NIFs/drivers inside Erlang apps.  The [rust.mk readme](https://github.com/goertzenator/rust.mk) explains what it all does.