### PR TITLE
Add PROJECT_MOD var to make the app callback module configurable

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -24,6 +24,7 @@ PROJECT ?= $(notdir $(CURDIR))
 PROJECT := $(strip $(PROJECT))
 
 PROJECT_VERSION ?= rolling
+PROJECT_MOD ?= $(PROJECT)_app
 
 # Verbosity.
 

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -59,7 +59,7 @@ app:: clean deps $(PROJECT).d
 	$(verbose) $(MAKE) --no-print-directory app-build
 endif
 
-ifeq ($(wildcard src/$(PROJECT)_app.erl),)
+ifeq ($(wildcard src/$(PROJECT_MOD).erl),)
 define app_file
 {application, $(PROJECT), [
 	{description, "$(PROJECT_DESCRIPTION)"},
@@ -79,7 +79,7 @@ define app_file
 	{modules, [$(call comma_list,$(2))]},
 	{registered, [$(call comma_list,$(PROJECT)_sup $(PROJECT_REGISTERED))]},
 	{applications, [$(call comma_list,kernel stdlib $(OTP_DEPS) $(LOCAL_DEPS) $(DEPS))]},
-	{mod, {$(PROJECT)_app, []}}
+	{mod, {$(PROJECT_MOD), []}}
 ]}.
 endef
 endif

--- a/doc/src/guide/app.asciidoc
+++ b/doc/src/guide/app.asciidoc
@@ -126,6 +126,8 @@ your situation.
 	Short description of the project.
 `PROJECT_VERSION`::
 	Current version of the project.
+`PROJECT_MOD`::
+        The application callback module.
 `PROJECT_REGISTERED`::
 	List of the names of all registered processes.
 `LOCAL_DEPS`::


### PR DESCRIPTION
I have many projects in which the application callback module (mod key in .app) is not called $(PROJECT)_app.erl, this is a very small change to make it configurable.