### PR TITLE
Fix rust.mk package info

### DIFF
--- a/index/rust.mk
+++ b/index/rust.mk
@@ -1,7 +1,0 @@
-PACKAGES += rust
-pkg_rust_name = rust
-pkg_rust_description = Build Rust crates in an Erlang application
-pkg_rust_homepage = https://github.com/goertzenator/rust.mk
-pkg_rust_fetch = git
-pkg_rust_repo = https://github.com/goertzenator/rust.mk
-pkg_rust_commit = master

--- a/index/rust_mk.mk
+++ b/index/rust_mk.mk
@@ -1,0 +1,7 @@
+PACKAGES += rust_mk
+pkg_rust_mk_name = rust_mk
+pkg_rust_mk_description = Build Rust crates in an Erlang application
+pkg_rust_mk_homepage = https://github.com/goertzenator/rust.mk
+pkg_rust_mk_fetch = git
+pkg_rust_mk_repo = https://github.com/goertzenator/rust.mk
+pkg_rust_mk_commit = master


### PR DESCRIPTION
I've misunderstood a few things about plugins and have recast the Rust.mk plugin in the image of `reload_mk.mk`.