### PR TITLE
Fix several problems with the erlydtl plugin:

### DIFF
--- a/plugins/erlydtl.mk
+++ b/plugins/erlydtl.mk
@@ -15,19 +15,14 @@ dtl_verbose = $(dtl_verbose_$(V))
 
 # Core targets.
 
-DTL_FILES = $(sort $(call core_find,$(DTL_PATH),*.dtl))
+DTL_PATH := $(abspath $(DTL_PATH))
+DTL_FILES = $(call core_find,$(DTL_PATH),*.dtl)
 
 ifneq ($(DTL_FILES),)
 
-ifdef DTL_FULL_PATH
-BEAM_FILES += $(addprefix ebin/,$(patsubst %.dtl,%_dtl.beam,$(subst /,_,$(DTL_FILES:$(DTL_PATH)%=%))))
-else
-BEAM_FILES += $(addprefix ebin/,$(patsubst %.dtl,%_dtl.beam,$(notdir $(DTL_FILES))))
-endif
-
-# Rebuild templates when the Makefile changes.
-$(DTL_FILES): $(MAKEFILE_LIST)
-	@touch $@
+DTL_NAMES   = $(addsuffix $(DTL_SUFFIX),$(DTL_FILES:$(DTL_PATH)/%.dtl=%))
+DTL_MODULES = $(if $(DTL_FULL_PATH),$(subst /,_,$(DTL_NAMES)),$(notdir $(DTL_NAMES)))
+BEAM_FILES += $(addsuffix .beam,$(addprefix ebin/,$(DTL_MODULES)))
 
 define erlydtl_compile.erl
 	[begin
@@ -35,11 +30,11 @@ define erlydtl_compile.erl
 			"" ->
 				filename:basename(F, ".dtl");
 			_ ->
-				"$(DTL_PATH)" ++ F2 = filename:rootname(F, ".dtl"),
+				"$(DTL_PATH)/" ++ F2 = filename:rootname(F, ".dtl"),
 				re:replace(F2, "/",  "_",  [{return, list}, global])
 		end,
 		Module = list_to_atom(string:to_lower(Module0) ++ "$(DTL_SUFFIX)"),
-		case erlydtl:compile(F, Module, [$(DTL_OPTS)] ++ [{out_dir, "ebin/"}, return_errors, {doc_root, "templates"}]) of
+		case erlydtl:compile(F, Module, [$(DTL_OPTS)] ++ [{out_dir, "ebin/"}, return_errors]) of
 			ok -> ok;
 			{ok, _} -> ok
 		end

--- a/test/plugin_erlydtl.mk
+++ b/test/plugin_erlydtl.mk
@@ -1,6 +1,6 @@
 # ErlyDTL plugin.
 
-ERLYDTL_CASES = compile full-path opts
+ERLYDTL_CASES = compile full-path suffix path-full-path-suffix opts
 ERLYDTL_TARGETS = $(addprefix erlydtl-,$(ERLYDTL_CASES))
 
 .PHONY: erlydtl $(ERLYDTL_TARGETS)
@@ -61,6 +61,56 @@ erlydtl-full-path: build clean
 	$t $(ERL) -pa $(APP)/ebin/ -eval " \
 		ok = application:load($(APP)), \
 		{ok, [deep_$(APP)_two_dtl, $(APP_)_one_dtl]} = application:get_key($(APP), modules), \
+		halt()"
+
+erlydtl-suffix: build clean
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Generate ErlyDTL templates"
+	$t mkdir $(APP)/templates/
+	$t touch $(APP)/templates/one.dtl
+	$t touch $(APP)/templates/two.dtl
+
+	$i "Build the application"
+	$t $(MAKE) -C $(APP) DEPS=erlydtl DTL_SUFFIX= $v
+
+	$i "Check that ErlyDTL templates are compiled"
+	$t test -f $(APP)/ebin/one.beam
+	$t test -f $(APP)/ebin/two.beam
+
+	$i "Check that ErlyDTL generated modules are included in .app file"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		ok = application:load($(APP)), \
+		{ok, [one, two]} = application:get_key($(APP), modules), \
+		halt()"
+
+erlydtl-path-full-path-suffix: build clean
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Generate ErlyDTL templates"
+	$t mkdir -p $(APP)/dtl/two/
+	$t touch $(APP)/dtl/one.dtl
+	$t touch $(APP)/dtl/two/three.dtl
+
+	$i "Build the application"
+	$t $(MAKE) -C $(APP) DEPS=erlydtl DTL_PATH=dtl DTL_FULL_PATH=1 DTL_SUFFIX=_suffix $v
+
+	$i "Check that ErlyDTL templates are compiled"
+	$t test -f $(APP)/ebin/one_suffix.beam
+	$t test -f $(APP)/ebin/two_three_suffix.beam
+
+	$i "Check that ErlyDTL generated modules are included in .app file"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		ok = application:load($(APP)), \
+		{ok, [one_suffix, two_three_suffix]} = application:get_key($(APP), modules), \
 		halt()"
 
 erlydtl-opts: build clean


### PR DESCRIPTION
DTL_SUFFIX:
 - make sure it is actually used
 - add a test for it (and one combined with other options)

DTL_PATH:
 - handle correctly with or without trailing /
 - don't hard-code the `doc_root` opt - the erlydtl default is better

DTL_FILES:
 - the user should be able to generate template files before compiling
   therefore do not define any targets for these, so that they may do so