### PR TITLE
fix test clean ordering

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -203,3 +203,12 @@ endif
 
 # The erlang.mk package index is bundled in the default erlang.mk build.
 # Search for the string "copyright" to skip to the rest of the code.
+
+# app/test-build clean rules must appear here before any others
+ifeq ($(wildcard ebin/test),)
+test-build:: clean
+	mkdir -p ebin
+	touch ebin/test
+else
+app:: clean
+endif

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -51,13 +51,8 @@ ifneq ($(wildcard src/),)
 
 # Targets.
 
-ifeq ($(wildcard ebin/test),)
 app:: deps $(PROJECT).d
 	$(verbose) $(MAKE) --no-print-directory app-build
-else
-app:: clean deps $(PROJECT).d
-	$(verbose) $(MAKE) --no-print-directory app-build
-endif
 
 ifeq ($(wildcard src/$(PROJECT_MOD).erl),)
 define app_file

--- a/core/test.mk
+++ b/core/test.mk
@@ -31,19 +31,12 @@ endif
 
 ifeq ($(wildcard src),)
 test-build:: ERLC_OPTS=$(TEST_ERLC_OPTS)
-test-build:: clean deps test-deps
+test-build:: deps test-deps
 	$(verbose) $(MAKE) --no-print-directory test-dir ERLC_OPTS="$(TEST_ERLC_OPTS)"
-else
-ifeq ($(wildcard ebin/test),)
-test-build:: ERLC_OPTS=$(TEST_ERLC_OPTS)
-test-build:: clean deps test-deps $(PROJECT).d
-	$(verbose) $(MAKE) --no-print-directory app-build test-dir ERLC_OPTS="$(TEST_ERLC_OPTS)"
-	$(gen_verbose) touch ebin/test
 else
 test-build:: ERLC_OPTS=$(TEST_ERLC_OPTS)
 test-build:: deps test-deps $(PROJECT).d
 	$(verbose) $(MAKE) --no-print-directory app-build test-dir ERLC_OPTS="$(TEST_ERLC_OPTS)"
-endif
 
 clean:: clean-test-dir
 


### PR DESCRIPTION
External plugins had their test-build artifacts cleaned after build
but before actual testing.  This forces cleaning to take place before
building.

Ref #573
