### PR TITLE
Build subapps only once

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -12,7 +12,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-.PHONY: all app deps search rel docs install-docs check tests clean distclean help erlang-mk
+.PHONY: all app apps deps search rel docs install-docs check tests clean distclean help erlang-mk
 
 ERLANG_MK_FILENAME := $(realpath $(lastword $(MAKEFILE_LIST)))
 

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -48,7 +48,14 @@ dep_verbose = $(dep_verbose_$(V))
 
 # Core targets.
 
-ifndef SUBMAKE
+is_app_or_dep = no
+ifdef IS_APP
+	is_app_or_dep = yes
+endif
+ifdef IS_DEP
+	is_app_or_dep = yes
+endif
+ifeq ($(is_app_or_dep),no)
 apps::
 	$(verbose) mkdir -p $(ERLANG_MK_TMP)
 	$(verbose) rm -f $(ERLANG_MK_TMP)/apps.log
@@ -72,7 +79,7 @@ apps:: $(ALL_APPS_DIRS)
 			:; \
 		else \
 			echo $$dep >> $(ERLANG_MK_TMP)/apps.log; \
-			$(MAKE) -C $$dep IS_APP=1 SUBMAKE=1 || exit $$?; \
+			$(MAKE) -C $$dep IS_APP=1 || exit $$?; \
 		fi \
 	done
 endif
@@ -87,7 +94,7 @@ deps:: $(ALL_DEPS_DIRS) apps
 		else \
 			echo $$dep >> $(ERLANG_MK_TMP)/deps.log; \
 			if [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ]; then \
-				$(MAKE) -C $$dep IS_DEP=1 SUBMAKE=1 || exit $$?; \
+				$(MAKE) -C $$dep IS_DEP=1 || exit $$?; \
 			else \
 				echo "Error: No Makefile to build dependency $$dep."; \
 				exit 2; \

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2015, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
-.PHONY: apps distclean-deps
+.PHONY: distclean-deps
 
 # Configuration.
 

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -55,8 +55,12 @@ apps:: $(ALL_APPS_DIRS)
 ifneq ($(IS_DEP),1)
 	$(verbose) rm -f $(ERLANG_MK_TMP)/apps.log
 endif
+# mkdir in separate loop for erl to recognize each other app as valid for the sake of include_lib
+# when compiling.
 	$(verbose) for dep in $(ALL_APPS_DIRS) ; do \
 		mkdir -p $$dep/ebin || exit $$?; \
+	done
+	$(verbose) for dep in $(ALL_APPS_DIRS) ; do \
 		if grep -qs ^$$dep$$ $(ERLANG_MK_TMP)/apps.log; then \
 			:; \
 		else \

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -231,7 +231,8 @@ ebin/:
 
 define compile_erl
 	$(erlc_verbose) erlc -v $(if $(IS_DEP),$(filter-out -Werror,$(ERLC_OPTS)),$(ERLC_OPTS)) -o ebin/ \
-		-pa ebin/ -I include/ $(filter-out $(ERLC_EXCLUDE_PATHS),$(COMPILE_FIRST_PATHS) $(1))
+		-pa ebin/ -I $(APPS_DIR) -I $(DEPS_DIR) -I include/ \
+		$(filter-out $(ERLC_EXCLUDE_PATHS),$(COMPILE_FIRST_PATHS) $(1))
 endef
 
 ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.src)

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -231,8 +231,7 @@ ebin/:
 
 define compile_erl
 	$(erlc_verbose) erlc -v $(if $(IS_DEP),$(filter-out -Werror,$(ERLC_OPTS)),$(ERLC_OPTS)) -o ebin/ \
-		-pa ebin/ -I $(APPS_DIR) -I $(DEPS_DIR) -I include/ \
-		$(filter-out $(ERLC_EXCLUDE_PATHS),$(COMPILE_FIRST_PATHS) $(1))
+		-pa ebin/ -I include/ $(filter-out $(ERLC_EXCLUDE_PATHS),$(COMPILE_FIRST_PATHS) $(1))
 endef
 
 ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.src)

--- a/test/core_deps.mk
+++ b/test/core_deps.mk
@@ -139,6 +139,8 @@ core-deps-apps-deep-conflict: build clean
 	$i "Check that Cowlib wasn't fetched"
 	$t test ! -e $(APP)/deps/cowlib
 
+# Ensure that each APPS_DIR app isn't built multiple times when the project have multiple
+# dependencies.
 core-deps-apps-build-count: build clean
 
 	$i "Bootstrap a new OTP library named $(APP)"
@@ -171,6 +173,7 @@ core-deps-apps-build-count: build clean
 	$i "Build the application"
 	$t $(MAKE) -C $(APP) $v
 
+# Checking against 2 or lower since each app is built an extra time in some cases.
 	$i "Check the number of times each app was compiled"
 	$t test "`wc -c $(APP)/apps/app_one/count | awk '{printf $$1}'`" -le 2
 	$t test "`wc -c $(APP)/apps/app_two/count | awk '{printf $$1}'`" -le 2

--- a/test/core_deps.mk
+++ b/test/core_deps.mk
@@ -163,20 +163,20 @@ core-deps-apps-build-count: build clean
 	$i "Create a new application app_one"
 	$t $(MAKE) -C $(APP) new-app in=app_one $v
 	$t echo "all::" >> $(APP)/apps/app_one/Makefile
-	$t echo "	echo -n '#' >> count" >> $(APP)/apps/app_one/Makefile
+	$t echo "	@echo -n '#' >> count" >> $(APP)/apps/app_one/Makefile
 
 	$i "Create a new application app_two"
 	$t $(MAKE) -C $(APP) new-app in=app_two $v
 	$t echo "all::" >> $(APP)/apps/app_two/Makefile
-	$t echo "	echo -n '#' >> count" >> $(APP)/apps/app_two/Makefile
+	$t echo "	@echo -n '#' >> count" >> $(APP)/apps/app_two/Makefile
 
 	$i "Build the application"
 	$t $(MAKE) -C $(APP) $v
 
 # Checking against 2 or lower since each app is built an extra time in some cases.
 	$i "Check the number of times each app was compiled"
-	$t test "`wc -c $(APP)/apps/app_one/count | awk '{printf $$1}'`" -le 2
-	$t test "`wc -c $(APP)/apps/app_two/count | awk '{printf $$1}'`" -le 2
+	$t test "`wc -c $(APP)/apps/app_one/count | awk '{printf $$1}'`" -eq 1
+	$t test "`wc -c $(APP)/apps/app_two/count | awk '{printf $$1}'`" -eq 1
 
 core-deps-apps-dir: build clean
 


### PR DESCRIPTION
Implemented similar behavior when handling dependencies to avoid running make
once for each APPS_DIR sub application for every DEPS_DIR dependency. Instead keep track of which apps that have been built. This also adds the "apps" target that compiles only APPS_DIRS and not DEPS_DIR.

Resolves #531 