### PR TITLE
dialyzer.mk: Use the shell to parse command line args

### DIFF
--- a/test/plugin_dialyzer.mk
+++ b/test/plugin_dialyzer.mk
@@ -166,18 +166,18 @@ dialyzer-erlc-opts: build clean
 	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap $v
 
 	$i "Create a header file in a non-standard directory"
-	$t mkdir $(APP)/exotic/
-	$t touch $(APP)/exotic/dialyze.hrl
+	$t mkdir $(APP)/exotic-include-path/
+	$t touch $(APP)/exotic-include-path/dialyze.hrl
 
 	$i "Create a module that includes this header"
 	$t printf "%s\n" \
 		"-module(no_warn)." \
 		"-export([doit/0])." \
 		"-include(\"dialyze.hrl\")." \
-		"doit() -> ok." > $(APP)/src/no_warn.erl
+		"doit() -> ?OK." > $(APP)/src/no_warn.erl
 
 	$i "Point ERLC_OPTS to the non-standard include directory"
-	$t perl -ni.bak -e 'print;if ($$.==1) {print "ERLC_OPTS += -I exotic\n"}' $(APP)/Makefile
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "ERLC_OPTS += -I exotic-include-path -DOK=ok\n"}' $(APP)/Makefile
 
 	$i "Run Dialyzer"
 	$t $(DIALYZER_MUTEX) $(MAKE) -C $(APP) dialyze $v


### PR DESCRIPTION
Splitting arguments on `-` was dangerous: if a path contained such a character, it would be split and the second half thrown away by the filtering.

Now, `$(ERLC_OPTS)` is passed to erl(1) after `-extra`. Thus arguments parsing is done by the shell and we only have to call `init:get_plain_arguments/0` to get them as a list.