### PR TITLE
Add support for customized prologue when compiling yecc (yrl) files.

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -132,7 +132,7 @@ YRL_ERL_FILES = $(addprefix src/,$(patsubst %.yrl,%.erl,$(notdir $(YRL_FILES))))
 ERL_FILES += $(YRL_ERL_FILES)
 
 $(PROJECT).d:: $(XRL_FILES) $(YRL_FILES)
-	$(if $(strip $?),$(xyrl_verbose) erlc -v -o src/ $?)
+	$(if $(strip $?),$(xyrl_verbose) erlc -v -o src/ $(YRL_ERLC_OPTS) $?)
 
 # Erlang and Core Erlang files.
 

--- a/test/core_app.mk
+++ b/test/core_app.mk
@@ -1,6 +1,6 @@
 # Core: Building applications.
 
-CORE_APP_CASES = appsrc-change asn1 auto-git-id erlc-exclude erlc-opts erlc-opts-filter error generate-erl generate-erl-include generate-erl-prepend hrl hrl-recursive makefile-change mib no-app no-makedep project-mod pt pt-erlc-opts xrl xrl-include yrl yrl-include
+CORE_APP_CASES = appsrc-change asn1 auto-git-id erlc-exclude erlc-opts erlc-opts-filter error generate-erl generate-erl-include generate-erl-prepend hrl hrl-recursive makefile-change mib no-app no-makedep project-mod pt pt-erlc-opts xrl xrl-include yrl yrl-include yrl-header
 CORE_APP_TARGETS = $(addprefix core-app-,$(CORE_APP_CASES))
 
 .PHONY: core-app $(CORE_APP_TARGETS)
@@ -1442,6 +1442,74 @@ endif
 	$t $(ERL) -pa $(APP)/ebin/ -eval " \
 		ok = application:start($(APP)), \
 		{ok, Mods = [boy, girl, xmerl_xpath_parse, xref_parser]} \
+			= application:get_key($(APP), modules), \
+		[{module, M} = code:load_file(M) || M <- Mods], \
+		halt()"
+
+core-app-yrl-header: build clean
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+	
+	$i "Create a .yrl file"
+	$t echo "Nonterminals E T F." > $(APP)/src/y_parse.yrl
+	$t echo "Terminals '+' '*' '(' ')' number." >> $(APP)/src/y_parse.yrl
+	$t echo "Rootsymbol E." >> $(APP)/src/y_parse.yrl
+	$t echo "E -> E '+' T: {'\$$2', '\$$1', '\$$3'}." >> $(APP)/src/y_parse.yrl
+	$t echo "E -> T : '\$$1'." >> $(APP)/src/y_parse.yrl
+	$t echo "T -> T '*' F: {'\$$2', '\$$1', '\$$3'}." >> $(APP)/src/y_parse.yrl
+	$t echo "T -> F : '\$$1'." >> $(APP)/src/y_parse.yrl
+	$t echo "F -> '(' E ')' : '\$$2'." >> $(APP)/src/y_parse.yrl
+	$t echo "F -> number : '\$$1'. " >> $(APP)/src/y_parse.yrl
+
+	$i "Create the yrl header file"
+	$t mkdir $(APP)/include
+	$t echo "-export([forty_two/0])." > $(APP)/include/yecc_header.hrl
+	# a bunch of gobbldygook we don't actually care about, we just
+	# need to exist so we don't get errors.
+	$t echo "-export([ yeccpars1/5, yeccerror/1, yeccpars2/7, yeccpars2_0/7, yeccpars2_1/7, yeccpars2_2/7, yeccpars2_3/7, yeccpars2_5/7, yeccpars2_6/7, yeccpars2_7/7, yeccpars2_9/7, yeccpars2_11/7, 'yeccgoto_\'E\''/7, 'yeccgoto_\'F\''/7, 'yeccgoto_\'T\''/7, yeccpars2_9_/1, yeccpars2_11_/1, yeccpars2_7_/1])." >> $(APP)/include/yecc_header.hrl
+	$t echo "yeccpars1(_,_,_,_,_) -> throw(not_implemented)." >> $(APP)/include/yecc_header.hrl
+	$t echo "yeccerror(_) -> throw(not_implemented)." >> $(APP)/include/yecc_header.hrl
+	# and required bits done, now part we'll actually test for.
+	$t echo "forty_two() -> 42." >> $(APP)/include/yecc_header.hrl
+
+
+	$i "Generate unrelated .erl files"
+	$t echo "-module(boy)." > $(APP)/src/boy.erl
+	$t echo "-module(girl)." > $(APP)/src/girl.erl
+
+	$i "Build the application"
+	$t YRL_ERLC_OPTS="-I include/yecc_header.hrl" $(MAKE) -C $(APP) $v
+#	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that all compiled files exist"
+	$t test -f $(APP)/$(APP).d
+	$t test -f $(APP)/ebin/$(APP).app
+	$t test -f $(APP)/ebin/boy.beam
+	$t test -f $(APP)/ebin/girl.beam
+	$t test -f $(APP)/ebin/y_parse.beam
+	$t test -f $(APP)/src/y_parse.erl
+
+	$i "Check that the application was compiled correctly"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		ok = application:start($(APP)), \
+		{ok, Mods = [boy, girl, y_parse]} \
+			= application:get_key($(APP), modules), \
+		[{module, M} = code:load_file(M) || M <- Mods], \
+		halt()"
+
+	$i "Check the built yecc module used the header"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		{module, y_parse} = code:load_file(y_parse), \
+		42 = y_parse:forty_two(), \
+		halt()"
+
+	$i "Check that the application was compiled correctly"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		ok = application:start($(APP)), \
+		{ok, Mods = [boy, girl, y_parse]} \
 			= application:get_key($(APP), modules), \
 		[{module, M} = code:load_file(M) || M <- Mods], \
 		halt()"


### PR DESCRIPTION
The documentation for erlc allows the use of `-I` to define a custom prologue to use when compiling yacc source files. This is an option available in rebar. However, there does not exist a way to define a custom prologue in erlang.mk. This adds a variable one can set allowing one to not only define a custom prologue, buy any additional erlc options one my want.