### PR TITLE
Add package chumak to the index

### DIFF
--- a/index/chumak.mk
+++ b/index/chumak.mk
@@ -1,0 +1,7 @@
+PACKAGES += chumak
+pkg_chumak_name = chumak
+pkg_chumak_description = Pure Erlang implementation of ZeroMQ Message Transport Protocol.
+pkg_chumak_homepage = http://choven.ca
+pkg_chumak_fetch = git
+pkg_chumak_repo = https://github.com/chovencorp/chumak
+pkg_chumak_commit = 1.1.1

--- a/index/erlangzmq.mk
+++ b/index/erlangzmq.mk
@@ -1,7 +1,0 @@
-PACKAGES += erlangzmq
-pkg_erlangzmq_name = erlangzmq
-pkg_erlangzmq_description = Native Erlang implemention of ZeroMQ Message Transport Protocol.
-pkg_erlangzmq_homepage = http://choven.ca
-pkg_erlangzmq_fetch = git
-pkg_erlangzmq_repo = https://github.com/chovencorp/erlangzmq
-pkg_erlangzmq_commit = master


### PR DESCRIPTION
This is the same package as `erlangzmq` only name and license are changed.

If possible, please delete `erlangzmq` from the index.