### PR TITLE
Support C compiler flag overrides for dependencies

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -334,9 +334,9 @@ define dep_autopatch_rebar.erl
 		[] -> ok;
 		_ ->
 			Write("\npre-app::\n\t$$\(MAKE) -f c_src/Makefile.erlang.mk\n"),
-			PortSpecWrite(io_lib:format("ERL_CFLAGS = -finline-functions -Wall -fPIC -I \\"~s/erts-~s/include\\" -I \\"~s\\"\n",
+			PortSpecWrite(io_lib:format("ERL_CFLAGS ?= -finline-functions -Wall -fPIC -I \\"~s/erts-~s/include\\" -I \\"~s\\"\n",
 				[code:root_dir(), erlang:system_info(version), code:lib_dir(erl_interface, include)])),
-			PortSpecWrite(io_lib:format("ERL_LDFLAGS = -L \\"~s\\" -lerl_interface -lei\n",
+			PortSpecWrite(io_lib:format("ERL_LDFLAGS ?= -L \\"~s\\" -lerl_interface -lei\n",
 				[code:lib_dir(erl_interface, lib)])),
 			[PortSpecWrite(["\n", E, "\n"]) || E <- OsEnv],
 			FilterEnv = fun(Env) ->


### PR DESCRIPTION
This change makes it possible to override the ERL_CFLAGS and ERL_LDFLAGS
Makefile variables in project dependencies. For the main project, the
ability to override variables associated with C compilation already
existed in plugins/c_src.mk. With this change, the C compiler flag
semantics are similar for both the main project and dependencies.

This is important for cases where the automatically determined values
for the ERTS include and library directories are incorrect. This happens
in cross-compiled environments where they point to the host's include
and library directories. However, the desired behaviour is to have them
point to those that have been cross-compiled for the target.