### PR TITLE
Fix erlexec application name

### DIFF
--- a/index/exec.mk
+++ b/index/exec.mk
@@ -1,5 +1,5 @@
 PACKAGES += exec
-pkg_exec_name = exec
+pkg_exec_name = erlexec
 pkg_exec_description = Execute and control OS processes from Erlang/OTP.
 pkg_exec_homepage = http://saleyn.github.com/erlexec
 pkg_exec_fetch = git


### PR DESCRIPTION
erlexec now requires that particular name in order to successfully boot.