### PR TITLE
Support PROJECT_APP_EXTRA_KEYS to add keys to the .app file

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -68,7 +68,7 @@ define app_file
 	{modules, [$(call comma_list,$(2))]},
 	{registered, []},
 	{applications, [$(call comma_list,kernel stdlib $(OTP_DEPS) $(LOCAL_DEPS) $(DEPS))]},
-	{env, $(subst \,\\,$(PROJECT_ENV))}
+	{env, $(subst \,\\,$(PROJECT_ENV))}$(if $(findstring {,$(PROJECT_APP_EXTRA_KEYS)),$(comma)$(newline)$(tab)$(subst \,\\,$(PROJECT_APP_EXTRA_KEYS)),)
 ]}.
 endef
 else
@@ -81,7 +81,7 @@ define app_file
 	{registered, [$(call comma_list,$(PROJECT)_sup $(PROJECT_REGISTERED))]},
 	{applications, [$(call comma_list,kernel stdlib $(OTP_DEPS) $(LOCAL_DEPS) $(DEPS))]},
 	{mod, {$(PROJECT_MOD), []}},
-	{env, $(subst \,\\,$(PROJECT_ENV))}
+	{env, $(subst \,\\,$(PROJECT_ENV))}$(if $(findstring {,$(PROJECT_APP_EXTRA_KEYS)),$(comma)$(newline)$(tab)$(subst \,\\,$(PROJECT_APP_EXTRA_KEYS)),)
 ]}.
 endef
 endif

--- a/doc/src/guide/app.asciidoc
+++ b/doc/src/guide/app.asciidoc
@@ -132,6 +132,11 @@ your situation.
 	List of the names of all registered processes.
 `PROJECT_ENV`::
 	Configuration parameters used by the application.
+`PROJECT_APP_EXTRA_KEYS`::
+	Other keys you want to add to the application `.app` file.
+	The variable content is written as-is to the `.app` file,
+	so be sure to format valid Erlang terms. For example:
+	`PROJECT_APP_EXTRA_KEYS = {maxT, 10000}, {start_phases, [...]}`.
 `LOCAL_DEPS`::
 	List of Erlang/OTP applications this project depends on,
 	excluding `erts`, `kernel` and `stdlib`, or list of

--- a/test/core_app.mk
+++ b/test/core_app.mk
@@ -1,6 +1,6 @@
 # Core: Building applications.
 
-CORE_APP_CASES = appsrc-change asn1 auto-git-id env erlc-exclude erlc-opts erlc-opts-filter error generate-erl generate-erl-include generate-erl-prepend hrl hrl-recursive makefile-change mib name-special-char no-app no-makedep project-mod pt pt-erlc-opts xrl xrl-include yrl yrl-header yrl-include
+CORE_APP_CASES = appsrc-change asn1 auto-git-id env erlc-exclude erlc-opts erlc-opts-filter error extra-keys generate-erl generate-erl-include generate-erl-prepend hrl hrl-recursive makefile-change mib name-special-char no-app no-makedep project-mod pt pt-erlc-opts xrl xrl-include yrl yrl-header yrl-include
 CORE_APP_TARGETS = $(addprefix core-app-,$(CORE_APP_CASES))
 
 .PHONY: core-app $(CORE_APP_TARGETS)
@@ -228,6 +228,45 @@ core-app-env: build clean
 		ok = application:load($(APP)), \
 		{ok, \"\\\"test_\\tvalue\\\"\"} = application:get_env($(APP), test_key), \
 		{ok, '\\\$$test'} = application:get_env($(APP), test_atom), \
+		halt()"
+
+core-app-extra-keys: build clean
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Define PROJECT_APP_EXTRA_KEYS"
+	$t printf "define PROJECT_APP_EXTRA_KEYS\n\t{maxT, 10000},\n\t{non_standard_key, test_value}\nendef\n" >> $(APP)/Makefile
+
+	$i "Build the application"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that the application was compiled correctly"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		ok = application:load($(APP)), \
+		{ok, 10000} = application:get_key($(APP), maxT), \
+		AppFile = filename:join(code:lib_dir($(APP), ebin), atom_to_list($(APP)) ++ \".app\"), \
+		{ok, [App]} = file:consult(AppFile), \
+		{application, $(APP), Props} = App, \
+		test_value = proplists:get_value(non_standard_key, Props),\
+		halt()"
+
+	$i "Define PROJECT_APP_EXTRA_KEYS with escape in string, special char"
+	$t echo "PROJECT_APP_EXTRA_KEYS = {non_standard_atom, '\\\$$\$$my_app'}, {non_standard_string, \"\\\"test_\\tvalue\\\"\"}" >> $(APP)/Makefile
+
+	$i "Build the application"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that the application was compiled correctly"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		ok = application:load($(APP)), \
+		AppFile = filename:join(code:lib_dir($(APP), ebin), atom_to_list($(APP)) ++ \".app\"), \
+		{ok, [App]} = file:consult(AppFile), \
+		{application, $(APP), Props} = App, \
+		'\\\$$my_app' = proplists:get_value(non_standard_atom, Props),\
+		\"\\\"test_\\tvalue\\\"\" = proplists:get_value(non_standard_string, Props),\
 		halt()"
 endif
 


### PR DESCRIPTION
This allows to add standard keys which do not have a corresponding `PROJECT_` Makefile variable, as well as non-standard keys.