### PR TITLE
Makefile: Set LC_COLLATE=C when building erlang.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ ERLANG_MK_VERSION = $(shell git describe --tags --dirty)
 .PHONY: all check
 
 all:
+	export LC_COLLATE=C; \
 	awk 'FNR==1 && NR!=1{print ""}1' $(patsubst %,%.mk,$(BUILD_CONFIG)) \
 		| sed 's/^ERLANG_MK_VERSION = .*/ERLANG_MK_VERSION = $(ERLANG_MK_VERSION)/' > $(ERLANG_MK)
 


### PR DESCRIPTION
When the index files are concatenated, (`index/*` in `build.config`), their order is related to the collation locale used by the shell. By explicitely setting this to the C locale, we make sure that the order is
consistent, no matter the user's locale.

It is especially useful in teams where users and systems have different locales.