### PR TITLE
plugins/syntastic.mk: New plugin to pass build options to Syntastic

### DIFF
--- a/build.config
+++ b/build.config
@@ -32,6 +32,7 @@ plugins/escript
 plugins/eunit
 plugins/relx
 plugins/shell
+plugins/syntastic
 plugins/triq
 plugins/xref
 

--- a/plugins/syntastic.mk
+++ b/plugins/syntastic.mk
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, Jean-Sébastien Pédron <jean-sebastien@rabbitmq.com>
+# This file is contributed to erlang.mk and subject to the terms of the ISC License.
+
+.PHONY: show-ERL_LIBS show-ERLC_OPTS show-TEST_ERLC_OPTS
+
+show-ERL_LIBS:
+	@echo $(ERL_LIBS)
+
+show-ERLC_OPTS:
+	@$(foreach opt,$(ERLC_OPTS) -pa ebin -I include,echo "$(opt)";)
+
+show-TEST_ERLC_OPTS:
+	@$(foreach opt,$(TEST_ERLC_OPTS) -pa ebin -I include,echo "$(opt)";)


### PR DESCRIPTION
Syntastic, an Erlang syntax checker plugin for Vim, uses the Erlang compile application to get compilation errors and warnings. Therefore it needs cooperation from the build system to get the appropriate compile
flags.

Currently it supports Rebar by parsing the configuration file. To add support for Erlang.mk, we need new Make targets to return the compile flags.

This plugin adds three targets:

* `make show-ERL_LIBS`
* `make show-ERLC_OPTS`
* `make show-TEST_ERLC_OPTS`

Separate patches for Syntastic's builtin checker and syntaxerl are ready: they simply run those targets and parse the output.