### PR TITLE
Set ASN.1 compilation options using ERLC_ASN1_OPTS

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -12,6 +12,8 @@ COMPILE_FIRST_PATHS = $(addprefix src/,$(addsuffix .erl,$(COMPILE_FIRST)))
 ERLC_EXCLUDE ?=
 ERLC_EXCLUDE_PATHS = $(addprefix src/,$(addsuffix .erl,$(ERLC_EXCLUDE)))
 
+ERLC_ASN1_OPTS ?=
+
 ERLC_MIB_OPTS ?=
 COMPILE_MIB_FIRST ?=
 COMPILE_MIB_FIRST_PATHS = $(addprefix mibs/,$(addsuffix .mib,$(COMPILE_MIB_FIRST)))
@@ -104,7 +106,7 @@ ERL_FILES += $(addprefix src/,$(patsubst %.asn1,%.erl,$(notdir $(ASN1_FILES))))
 
 define compile_asn1
 	$(verbose) mkdir -p include/
-	$(asn1_verbose) erlc -v -I include/ -o asn1/ +noobj $(1)
+	$(asn1_verbose) erlc -v -I include/ -o asn1/ +noobj $(ERLC_ASN1_OPTS) $(1)
 	$(verbose) mv asn1/*.erl src/
 	$(verbose) mv asn1/*.hrl include/
 	$(verbose) mv asn1/*.asn1db include/

--- a/doc/src/guide/app.asciidoc
+++ b/doc/src/guide/app.asciidoc
@@ -284,6 +284,17 @@ include erlang.mk
 ERLC_OPTS := $(filter-out -Werror,$(ERLC_OPTS))
 ----
 
+==== ERLC_ASN1_OPTS
+
+`ERLC_ASN1_OPTS` can be used to pass compiler options when compiling
+ASN.1 files.  Please refer to the
+http://erlang.org/doc/man/asn1ct.html[asn1ct manual] for the full list.
+
+By default, Erlang.mk will leave this empty.
+
+You can redefine this variable in your Makefile.
+Please see the `ERLC_OPTS` section for instructions.
+
 ==== ERLC_EXCLUDE
 
 `ERLC_EXCLUDE` can be used to exclude some modules from the

--- a/test/core_app.mk
+++ b/test/core_app.mk
@@ -149,6 +149,21 @@ endif
 		[{module, M} = code:load_file(M) || M <- Mods], \
 		halt()"
 
+	$i "Clean the application"
+	$t $(MAKE) -C $(APP) clean $v
+
+	$i "Build the application with ERLC_ASN1_OPTS set"
+	$t echo "ERLC_ASN1_OPTS += +'{record_name_prefix,\"FOO-\"}'" >> $(APP)/Makefile
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that the application was built with ERLC_ASN1_OPTS set"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+	  Attrs = 'Def':module_info(attributes), \
+		Asn1Info = proplists:get_value(asn1_info, Attrs), \
+		Opts = proplists:get_value(options, Asn1Info), \
+		true = lists:member({record_name_prefix, \"FOO-\"}, Opts), \
+		halt()"
+
 core-app-auto-git-id: build clean
 
 	$i "Bootstrap a new OTP library named $(APP)"


### PR DESCRIPTION
`ERLC_ASN1_OPTS` can be used to pass compiler options when compiling
ASN.1 files. By default, Erlang.mk will leave this empty, but it can
be redefined in a Makefile.

This aims to implement the support requested in #658.