### PR TITLE
Fix Archlinux Installation Instructions

### DIFF
--- a/doc/src/guide/installation.asciidoc
+++ b/doc/src/guide/installation.asciidoc
@@ -22,7 +22,7 @@ The commands to install packages vary between distributions:
 
 .Arch Linux
 [source,bash]
-$ pacman -Sy erlang git make
+$ pacman -S erlang git make
 
 ==== FreeBSD
 


### PR DESCRIPTION
Suggesting -Sy is a terrible idea[1]. This commit replaces it with -Syu
which is the default on how packages should be added on Archlinux.

Resolves #662.

[1]: https://bbs.archlinux.org/viewtopic.php?id=89328