### PR TITLE
fix removing deps.log at toplevel when in a multi-app layout

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2016, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
-.PHONY: distclean-deps
+.PHONY: distclean-deps clean-tmp-deps.log
 
 # Configuration.
 
@@ -51,7 +51,7 @@ dep_verbose = $(dep_verbose_$(V))
 ifdef IS_APP
 apps::
 else
-apps:: $(ALL_APPS_DIRS) $(ERLANG_MK_TMP)/deps.log
+apps:: $(ALL_APPS_DIRS) clean-tmp-deps.log
 ifeq ($(IS_APP)$(IS_DEP),)
 	$(verbose) rm -f $(ERLANG_MK_TMP)/apps.log
 endif
@@ -72,14 +72,15 @@ endif
 	done
 endif
 
-$(ERLANG_MK_TMP)/deps.log::
+clean-tmp-deps.log:
 ifeq ($(IS_APP)$(IS_DEP),)
 	$(verbose) rm -f $(ERLANG_MK_TMP)/deps.log
 endif
+
 ifneq ($(SKIP_DEPS),)
 deps::
 else
-deps:: $(ALL_DEPS_DIRS) apps $(ERLANG_MK_TMP)/deps.log
+deps:: $(ALL_DEPS_DIRS) apps clean-tmp-deps.log
 	$(verbose) mkdir -p $(ERLANG_MK_TMP)
 	$(verbose) for dep in $(ALL_DEPS_DIRS) ; do \
 		if grep -qs ^$$dep$$ $(ERLANG_MK_TMP)/deps.log; then \

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -51,7 +51,7 @@ dep_verbose = $(dep_verbose_$(V))
 ifdef IS_APP
 apps::
 else
-apps:: $(ALL_APPS_DIRS)
+apps:: $(ALL_APPS_DIRS) $(ERLANG_MK_TMP)/deps.log
 ifeq ($(IS_APP)$(IS_DEP),)
 	$(verbose) rm -f $(ERLANG_MK_TMP)/apps.log
 endif
@@ -72,16 +72,14 @@ endif
 	done
 endif
 
-ifneq ($(SKIP_DEPS),)
-deps::
-else
-ifeq ($(ALL_DEPS_DIRS),)
-deps:: apps
-else
-deps:: $(ALL_DEPS_DIRS) apps
+$(ERLANG_MK_TMP)/deps.log::
 ifeq ($(IS_APP)$(IS_DEP),)
 	$(verbose) rm -f $(ERLANG_MK_TMP)/deps.log
 endif
+ifneq ($(SKIP_DEPS),)
+deps::
+else
+deps:: $(ALL_DEPS_DIRS) apps $(ERLANG_MK_TMP)/deps.log
 	$(verbose) mkdir -p $(ERLANG_MK_TMP)
 	$(verbose) for dep in $(ALL_DEPS_DIRS) ; do \
 		if grep -qs ^$$dep$$ $(ERLANG_MK_TMP)/deps.log; then \
@@ -96,7 +94,6 @@ endif
 			fi \
 		fi \
 	done
-endif
 endif
 
 # Deps related targets.

--- a/test/core_deps.mk
+++ b/test/core_deps.mk
@@ -33,7 +33,7 @@ core-deps-apps: build clean
 	$t test -f $(APP)/apps/my_app/ebin/my_app.app
 	$t test -f $(APP)/apps/my_app/ebin/boy.beam
 	$t test -f $(APP)/apps/my_app/ebin/girl.beam
-	$t test -d $(APP)/deps/cowlib
+	$t test -f $(APP)/deps/cowlib/ebin/cowlib.app
 
 # Applications in apps are compiled automatically but not added
 # to the application resource file unless they are listed in LOCAL_DEPS.
@@ -48,6 +48,18 @@ core-deps-apps: build clean
 		{ok, Mods = [boy, girl]} = application:get_key(my_app, modules), \
 		[{module, M} = code:load_file(M) || M <- Mods], \
 		halt()"
+
+	$i "Clean Cowlib"
+	$t $(MAKE) -C $(APP)/deps/cowlib clean $v
+
+	$i "Check that Cowlib compiled files were removed"
+	$t test ! -e $(APP)/deps/cowlib/ebin/cowlib.app
+
+	$i "Build the application again"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that Cowlib compiled files exist"
+	$t test -f $(APP)/deps/cowlib/ebin/cowlib.app
 
 	$i "Clean the application"
 	$t $(MAKE) -C $(APP) clean $v
@@ -427,7 +439,7 @@ core-deps-apps-only: build clean
 	$t test -f $(APP)/apps/my_app/ebin/my_app_app.beam
 	$t test -f $(APP)/apps/my_app/ebin/my_app_sup.beam
 	$t test -f $(APP)/apps/my_app/ebin/my_server.beam
-	$t test -d $(APP)/deps/cowlib/
+	$t test -f $(APP)/deps/cowlib/ebin/cowlib.app
 
 	$i "Check that the application was compiled correctly"
 	$t $(ERL) -pa $(APP)/apps/*/ebin/ -eval " \
@@ -435,6 +447,18 @@ core-deps-apps-only: build clean
 		{ok, Mods = [my_app_app, my_app_sup, my_server]} = application:get_key(my_app, modules), \
 		[{module, M} = code:load_file(M) || M <- Mods], \
 		halt()"
+
+	$i "Clean Cowlib"
+	$t $(MAKE) -C $(APP)/deps/cowlib clean $v
+
+	$i "Check that Cowlib compiled files were removed"
+	$t test ! -e $(APP)/deps/cowlib/ebin/cowlib.app
+
+	$i "Build the application again"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that Cowlib compiled files exist"
+	$t test -f $(APP)/deps/cowlib/ebin/cowlib.app
 
 	$i "Clean the application"
 	$t $(MAKE) -C $(APP) clean $v


### PR DESCRIPTION
`rm deps.log` was not being executed, because of 1) the ifeq around
it, checking for an empty ALL_DEPS_DIRS, which i believe was a logical
error; and 2) deps depended on apps, which means apps were compiled
before its recipe was executed, and the `rm deps.log` would be
executed after it had been written to by recursive make of the
apps.

the important reason to remove deps.log is so that dependencies get
remade when they change. otherwise you'll get mysterious errors about
missing dependencies if they need to be rebuilt, or worse, have wrong
stale beam files bundled in your release.

tests core-deps-apps and core-deps-apps-only now manually clean the
cowlib dep and rebuild at the top-level to make sure cowlib gets
rebuilt. both tests indeed fail without this fix.

this attempts to fix #1 by removing the ifeq, and #2 by having deps
and apps depend on deps.log, with deps.log 'built' (but actually
removed) by a double-colon rule with no prerequisites (which means its
recipe always be run).