### PR TITLE
making tar-ball generation optional with relx

### DIFF
--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -11,6 +11,11 @@ RELX_CONFIG ?= $(CURDIR)/relx.config
 RELX_URL ?= https://github.com/erlware/relx/releases/download/v3.19.0/relx
 RELX_OPTS ?=
 RELX_OUTPUT_DIR ?= _rel
+RELX_TAR ?= 1
+
+ifdef SFX
+	RELX_TAR = 1
+endif
 
 ifeq ($(firstword $(RELX_OPTS)),-o)
 	RELX_OUTPUT_DIR = $(word 2,$(RELX_OPTS))
@@ -37,10 +42,20 @@ $(RELX):
 	$(verbose) chmod +x $(RELX)
 
 relx-rel: $(RELX) rel-deps app
-	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release $(if $(SFX),tar)
+ifeq ($(RELX_TAR), 1)
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release tar
+else
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release
+endif
+
 
 relx-relup: $(RELX) rel-deps app
-	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup $(if $(SFX),tar)
+ifeq ($(RELX_TAR), 1)
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup tar
+else
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup
+endif
+
 
 distclean-relx-rel:
 	$(gen_verbose) rm -rf $(RELX_OUTPUT_DIR)

--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -11,6 +11,7 @@ RELX_CONFIG ?= $(CURDIR)/relx.config
 RELX_URL ?= https://github.com/erlware/relx/releases/download/v3.19.0/relx
 RELX_OPTS ?=
 RELX_OUTPUT_DIR ?= _rel
+RELX_DISABLE_TAR ?=
 
 ifeq ($(firstword $(RELX_OPTS)),-o)
 	RELX_OUTPUT_DIR = $(word 2,$(RELX_OPTS))
@@ -37,10 +38,10 @@ $(RELX):
 	$(verbose) chmod +x $(RELX)
 
 relx-rel: $(RELX) rel-deps app
-	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release tar
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release $(if $(RELX_DISABLE_TAR),,tar)
 
 relx-relup: $(RELX) rel-deps app
-	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup tar
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup $(if $(RELX_DISABLE_TAR),,tar)
 
 distclean-relx-rel:
 	$(gen_verbose) rm -rf $(RELX_OUTPUT_DIR)

--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -42,20 +42,18 @@ $(RELX):
 	$(verbose) chmod +x $(RELX)
 
 relx-rel: $(RELX) rel-deps app
-ifeq ($(RELX_TAR), 1)
+ifeq ($(RELX_TAR),1)
 	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release tar
 else
 	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release
 endif
 
-
 relx-relup: $(RELX) rel-deps app
-ifeq ($(RELX_TAR), 1)
+ifeq ($(RELX_TAR),1)
 	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup tar
 else
 	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup
 endif
-
 
 distclean-relx-rel:
 	$(gen_verbose) rm -rf $(RELX_OUTPUT_DIR)

--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -11,7 +11,6 @@ RELX_CONFIG ?= $(CURDIR)/relx.config
 RELX_URL ?= https://github.com/erlware/relx/releases/download/v3.19.0/relx
 RELX_OPTS ?=
 RELX_OUTPUT_DIR ?= _rel
-RELX_DISABLE_TAR ?=
 
 ifeq ($(firstword $(RELX_OPTS)),-o)
 	RELX_OUTPUT_DIR = $(word 2,$(RELX_OPTS))
@@ -38,10 +37,10 @@ $(RELX):
 	$(verbose) chmod +x $(RELX)
 
 relx-rel: $(RELX) rel-deps app
-	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release $(if $(RELX_DISABLE_TAR),,tar)
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release $(if $(SFX),tar)
 
 relx-relup: $(RELX) rel-deps app
-	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup $(if $(RELX_DISABLE_TAR),,tar)
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup $(if $(SFX),tar)
 
 distclean-relx-rel:
 	$(gen_verbose) rm -rf $(RELX_OUTPUT_DIR)


### PR DESCRIPTION
Make relx tar-ball generation optional with RELX_DISABLE_TAR environment variable as per discussion in #678. 

The old behaviour of generating the tar file is maintained is default if you do not set RELX_DISABLE_TAR. 

Usage: 
```
$ make -f erlang.mk bootstrap bootstrap-rel
$ RELX_DISABLE_TAR=1 make
```