### PR TITLE
Move external plugin loading at the end of erlang.mk

### DIFF
--- a/build.config
+++ b/build.config
@@ -40,5 +40,8 @@ plugins/xref
 plugins/cover
 plugins/sfx
 
+# External plugins.
+core/plugins
+
 # Core modules which can use variables from plugins.
 core/deps-tools

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -591,18 +591,3 @@ ERLANG_MK_RECURSIVE_DOC_DEPS_LIST = $(ERLANG_MK_TMP)/recursive-doc-deps-list.log
 ERLANG_MK_RECURSIVE_REL_DEPS_LIST = $(ERLANG_MK_TMP)/recursive-rel-deps-list.log
 ERLANG_MK_RECURSIVE_TEST_DEPS_LIST = $(ERLANG_MK_TMP)/recursive-test-deps-list.log
 ERLANG_MK_RECURSIVE_SHELL_DEPS_LIST = $(ERLANG_MK_TMP)/recursive-shell-deps-list.log
-
-# External plugins.
-
-DEP_PLUGINS ?=
-
-define core_dep_plugin
--include $(DEPS_DIR)/$(1)
-
-$(DEPS_DIR)/$(1): $(DEPS_DIR)/$(2) ;
-endef
-
-$(foreach p,$(DEP_PLUGINS),\
-	$(eval $(if $(findstring /,$p),\
-		$(call core_dep_plugin,$p,$(firstword $(subst /, ,$p))),\
-		$(call core_dep_plugin,$p/plugins.mk,$p))))

--- a/core/plugins.mk
+++ b/core/plugins.mk
@@ -1,0 +1,17 @@
+# Copyright (c) 2013-2017, Loïc Hoguin <essen@ninenines.eu>
+# This file is part of erlang.mk and subject to the terms of the ISC License.
+
+# External plugins.
+
+DEP_PLUGINS ?=
+
+define core_dep_plugin
+-include $(DEPS_DIR)/$(1)
+
+$(DEPS_DIR)/$(1): $(DEPS_DIR)/$(2) ;
+endef
+
+$(foreach p,$(DEP_PLUGINS),\
+	$(eval $(if $(findstring /,$p),\
+		$(call core_dep_plugin,$p,$(firstword $(subst /, ,$p))),\
+		$(call core_dep_plugin,$p/plugins.mk,$p))))


### PR DESCRIPTION
This allows all plugins to append to existing variables
and makes it easier to augment the functionality of the
core plugins.

This lets me write a plugin like this, for example:

``` makefile
THIS := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))

SOURCES += $(THIS)nif_helpers.c
$(C_SRC_OUTPUT_FILE): $(THIS)nif_helpers.o

ifeq ($(PLATFORM),msys2)
	CFLAGS += -I"$(THIS)/compat/"
endif

CFLAGS += -I"$(THIS)"
```

Feedback welcome!