### PR TITLE
plugins/xref.mk: Disable variable expansion in help message

### DIFF
--- a/plugins/xref.mk
+++ b/plugins/xref.mk
@@ -20,9 +20,9 @@ XREFR_URL ?= https://github.com/inaka/xref_runner/releases/download/0.2.2/xrefr
 # Core targets.
 
 help::
-	$(verbose) printf "%s\n" "" \
-		"Xref targets:" \
-		"  xref        Run Xrefr using $XREF_CONFIG as config file if defined"
+	$(verbose) printf '%s\n' '' \
+		'Xref targets:' \
+		'  xref        Run Xrefr using $$XREF_CONFIG as config file if defined'
 
 distclean:: distclean-xref
 


### PR DESCRIPTION
Before this change, the help message for this plugin was:

```
Xref targets:
  xref        Run Xrefr using REF_CONFIG as config file if defined
```

Note the missing `$X` before `REF_CONFIG`.