### PR TITLE
core/deps.mk: Move .app in autopatch2 only if file exists

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -129,6 +129,7 @@ define dep_autopatch
 endef
 
 define dep_autopatch2
+	! test -f $(DEPS_DIR)/$1/ebin/$1.app || \
 	mv -n $(DEPS_DIR)/$1/ebin/$1.app $(DEPS_DIR)/$1/src/$1.app.src; \
 	rm -f $(DEPS_DIR)/$1/ebin/$1.app; \
 	if [ -f $(DEPS_DIR)/$1/src/$1.app.src.script ]; then \


### PR DESCRIPTION
This silences warnings such as:

```
mv: rename file.app to file.app.src: No such file or directory
```

They are harmless really, but still annoying.