### PR TITLE
Support early-stage plugins through `$(DEP_EARLY_PLUGINS)`

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -21,6 +21,22 @@ export DEPS_DIR
 REBAR_DEPS_DIR = $(DEPS_DIR)
 export REBAR_DEPS_DIR
 
+# External "early" plugins (see core/plugins.mk for regular plugins).
+# They both use the core_dep_plugin macro.
+
+define core_dep_plugin
+-include $(DEPS_DIR)/$(1)
+
+$(DEPS_DIR)/$(1): $(DEPS_DIR)/$(2) ;
+endef
+
+DEP_EARLY_PLUGINS ?=
+
+$(foreach p,$(DEP_EARLY_PLUGINS),\
+	$(eval $(if $(findstring /,$p),\
+		$(call core_dep_plugin,$p,$(firstword $(subst /, ,$p))),\
+		$(call core_dep_plugin,$p/early-plugins.mk,$p))))
+
 dep_name = $(if $(dep_$(1)),$(1),$(if $(pkg_$(1)_name),$(pkg_$(1)_name),$(1)))
 dep_repo = $(patsubst git://github.com/%,https://github.com/%, \
 	$(if $(dep_$(1)),$(word 2,$(dep_$(1))),$(pkg_$(1)_repo)))

--- a/core/plugins.mk
+++ b/core/plugins.mk
@@ -5,12 +5,6 @@
 
 DEP_PLUGINS ?=
 
-define core_dep_plugin
--include $(DEPS_DIR)/$(1)
-
-$(DEPS_DIR)/$(1): $(DEPS_DIR)/$(2) ;
-endef
-
 $(foreach p,$(DEP_PLUGINS),\
 	$(eval $(if $(findstring /,$p),\
 		$(call core_dep_plugin,$p,$(firstword $(subst /, ,$p))),\

--- a/doc/src/guide/external_plugins.asciidoc
+++ b/doc/src/guide/external_plugins.asciidoc
@@ -75,3 +75,29 @@ The `THIS` variable is required to relatively include files.
 This allows users to not only be able to select individual
 plugins, but also select all plugins from the dependency
 in one go if they wish to do so.
+
+=== Early-stage plugins
+
+Plugins declared in `DEP_PLUGINS` are loaded near the end of Erlang.mk.
+That's why you have access to all previously initialized variables.
+However, if you want your plugin to add common dependencies to
+your applications, a regular is loaded too late in the process.
+You need to use "Early-stage plugins". They are declared using the
+`DEP_EARLY_PLUGINS` variable instead. Plugins listed in this variable
+are loaded near the beginning of Erlang.mk Otherwise, they work exactly
+the same.
+
+If you only give the name of a dependency, the default file loaded is
+'early-plugins.mk'. You can specify a filename exactly like you would
+have done it with regular plugins.
+
+[source,make]
+# In your application's Makefile
+BUILD_DEPS = common_deps
+DEP_EARLY_PLUGINS = common_deps
+
+[source,make]
+# In the plugin's early-plugins.mk
+DEPS += cowboy
+TEST_DEPS = ct_helper
+dep_ct_helper = git https://github.com/ninenines/ct_helper master


### PR DESCRIPTION
Regular plugins (`$(DEP_PLUGINS)`) are loaded near the end of Erlang.mk. This is fine when you want to modify variables initialized earlier in Erlang.mk or add new targets and variables.

However, it doesn't allow you to declare more dependencies because they are loaded too late for that.

This commit introduces a new variable, `$(DEP_EARLY_PLUGINS)`, which can be used to list plugins meant to be loaded near the beginning of Erlang.mk. Those allow to append to the list of dependencies.

They work exactly like regular plugins otherwise. The default filename loaded is `early-plugins.mk`.

See #687 for the discussion leading to this new feature.