### PR TITLE
Support plugins local to the application

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -25,9 +25,13 @@ export REBAR_DEPS_DIR
 # They both use the core_dep_plugin macro.
 
 define core_dep_plugin
+ifeq ($(2),$(PROJECT))
+-include $$(patsubst $(PROJECT)/%,%,$(1))
+else
 -include $(DEPS_DIR)/$(1)
 
 $(DEPS_DIR)/$(1): $(DEPS_DIR)/$(2) ;
+endif
 endef
 
 DEP_EARLY_PLUGINS ?=

--- a/doc/src/guide/external_plugins.asciidoc
+++ b/doc/src/guide/external_plugins.asciidoc
@@ -101,3 +101,31 @@ DEP_EARLY_PLUGINS = common_deps
 DEPS += cowboy
 TEST_DEPS = ct_helper
 dep_ct_helper = git https://github.com/ninenines/ct_helper master
+
+=== Loading  plugins local to the application
+
+If the Erlang.mk plugin lives in the same directory or repositoy as your
+application orlibrary, then you can load it exactly like an external
+plugin: the dependency name is simply the name of your application or
+library.
+
+For example, the following Makefile loads a plugin in the 'mk'
+subdirectory:
+
+[source,make]
+DEP_PLUGINS = $(PROJECT)/mk/dist.mk
+
+This also works with early-stage plugins:
+
+[source,make]
+DEP_EARLY_PLUGINS = $(PROJECT)/mk/variables.mk
+
+Like external plugins, if you do not specify the path to the plugin, it
+defaults to 'plugins.mk' or 'early-plugins.mk', located at the root of
+your application:
+
+[source,make]
+# Loads ./early-plugins.mk
+DEP_EARLY_PLUGINS = $(PROJECT)
+# Loads ./plugins.mk
+DEP_PLUGINS = $(PROJECT)


### PR DESCRIPTION
If the application's Makefile specify either:
```
DEP_PLUGINS = LOCAL
```
or e.g.:
```
DEP_PLUGINS = LOCAL/mk/dist.mk
```
then load the plugin from the application instead of a dependency.

This helps when you have an application with common Erlang modules and Erlang.mk plugins: your common application can load Erlang.mk plugins exactly like other applications depending on the common application.