### PR TITLE
plugins/xref.mk: Fetch xrefr 1.1.0

### DIFF
--- a/plugins/xref.mk
+++ b/plugins/xref.mk
@@ -15,7 +15,7 @@ endif
 XREFR ?= $(CURDIR)/xrefr
 export XREFR
 
-XREFR_URL ?= https://github.com/inaka/xref_runner/releases/download/0.2.2/xrefr
+XREFR_URL ?= https://github.com/inaka/xref_runner/releases/download/1.1.0/xrefr
 
 # Core targets.
 


### PR DESCRIPTION
In particular, xrefr 1.1.0 now exits with a non-zero exit status if there are any warnings reported. This makes `make xref` fail appropriately.