### PR TITLE
Update lager repository org.

### DIFF
--- a/index/lager.mk
+++ b/index/lager.mk
@@ -1,7 +1,7 @@
 PACKAGES += lager
 pkg_lager_name = lager
 pkg_lager_description = A logging framework for Erlang/OTP.
-pkg_lager_homepage = https://github.com/basho/lager
+pkg_lager_homepage = https://github.com/erlang-lager/lager
 pkg_lager_fetch = git
-pkg_lager_repo = https://github.com/basho/lager
+pkg_lager_repo = https://github.com/erlang-lager/lager
 pkg_lager_commit = master

--- a/index/lager_syslog.mk
+++ b/index/lager_syslog.mk
@@ -1,7 +1,7 @@
 PACKAGES += lager_syslog
 pkg_lager_syslog_name = lager_syslog
 pkg_lager_syslog_description = Syslog backend for lager
-pkg_lager_syslog_homepage = https://github.com/basho/lager_syslog
+pkg_lager_syslog_homepage = https://github.com/erlang-lager/lager_syslog
 pkg_lager_syslog_fetch = git
-pkg_lager_syslog_repo = https://github.com/basho/lager_syslog
+pkg_lager_syslog_repo = https://github.com/erlang-lager/lager_syslog
 pkg_lager_syslog_commit = master


### PR DESCRIPTION
[basho/lager](https://github.com/basho/lager) is unmaintained. A while ago, [erlang-lager/lager](https://github.com/erlang-lager/lager) project was started
to continue progress on lager, including support for recent OTP versions and rebar3.