### PR TITLE
Convert the run target to double-colon

### DIFF
--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -54,7 +54,7 @@ distclean-relx-rel:
 # Run target.
 
 ifeq ($(wildcard $(RELX_CONFIG)),)
-run:
+run::
 else
 
 define get_relx_release.erl
@@ -78,7 +78,7 @@ ifeq ($(PLATFORM),msys2)
 RELX_REL_EXT := .cmd
 endif
 
-run: all
+run:: all
 	$(verbose) $(RELX_OUTPUT_DIR)/$(RELX_REL_NAME)/bin/$(RELX_REL_NAME)$(RELX_REL_EXT) console
 
 help::


### PR DESCRIPTION
Related to #714 

Convert the run target to double-colon. This way the run target can be extended by users.