### PR TITLE
Make Triq plugin pick tests from $(TEST_DIR)

### DIFF
--- a/index/triq.mk
+++ b/index/triq.mk
@@ -1,7 +1,7 @@
 PACKAGES += triq
 pkg_triq_name = triq
 pkg_triq_description = Trifork QuickCheck
-pkg_triq_homepage = https://github.com/krestenkrab/triq
+pkg_triq_homepage = https://github.com/triqng/triq
 pkg_triq_fetch = git
-pkg_triq_repo = https://github.com/krestenkrab/triq
+pkg_triq_repo = https://github.com/triqng/triq.git
 pkg_triq_commit = master

--- a/plugins/triq.mk
+++ b/plugins/triq.mk
@@ -9,7 +9,7 @@ ifeq ($(filter triq,$(DEPS) $(TEST_DEPS)),triq)
 tests:: triq
 
 define triq_check.erl
-	code:add_pathsa(["$(call core_native_path,$(CURDIR)/ebin)", "$(call core_native_path,$(DEPS_DIR)/*/ebin)"]),
+	code:add_pathsa(["$(call core_native_path,$(CURDIR)/ebin)", "$(call core_native_path,$(DEPS_DIR)/*/ebin)", "$(call core_native_path,$(TEST_DIR))"]),
 	try
 		case $(1) of
 			all -> [true] =:= lists:usort([triq:check(M) || M <- [$(call comma_list,$(3))]]);
@@ -36,7 +36,7 @@ triq: test-build
 endif
 else
 triq: test-build
-	$(eval MODULES := $(patsubst %,'%',$(sort $(notdir $(basename $(wildcard ebin/*.beam))))))
+	$(eval MODULES := $(patsubst %,'%',$(sort $(notdir $(basename $(wildcard ebin/*.beam))) $(notdir $(basename $(call core_find,$(TEST_DIR)/,*.beam))))))
 	$(gen_verbose) $(call erlang,$(call triq_check.erl,all,undefined,$(MODULES)))
 endif
 endif

--- a/test/plugin_triq.mk
+++ b/test/plugin_triq.mk
@@ -1,0 +1,39 @@
+# Triq plugin
+
+TRIQ_CASES = test-dir
+TRIQ_TARGETS = $(addprefix triq-,$(TRIQ_CASES))
+
+.PHONY: triq $(TRIQ_TARGETS)
+
+triq: $(TRIQ_TARGETS)
+
+triq-test-dir: build clean
+	$i "Bootstrap a new OTP application named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap $v
+
+	$i "Add Triq to the list of dependencies"
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = triq\n"}' $(APP)/Makefile
+
+	$i "Generate a module containing Triq properties"
+	$t printf "%s\n" \
+		"-module($(APP))." \
+		"-ifdef(TEST)." \
+		"-include_lib(\"triq/include/triq.hrl\")." \
+		"prop_foo() -> ?FORALL(_, any(), true)." \
+		"-endif." > $(APP)/src/$(APP).erl
+
+	$i "Generate a module containing Triq properies in TEST_DIR"
+	$t mkdir $(APP)/test
+	$t printf "%s\n" \
+		"-module($(APP)_tests)." \
+		"-include_lib(\"triq/include/triq.hrl\")." \
+		"prop_bar() -> ?FORALL(_, any(), true)." > $(APP)/test/$(APP)_tests.erl
+
+	$i "Run the Triq plugin"
+	$t $(MAKE) -C $(APP) triq > $(APP)/triq.log
+
+	$i "Check that both properties were checked"
+	$t grep -q prop_foo $(APP)/triq.log
+	$t grep -q prop_bar $(APP)/triq.log


### PR DESCRIPTION
This commit also changes Triq repository in package index to point to the leading fork. The original repository doesn’t work in Erlang 20.

Fixes #716.