### PR TITLE
COVER_DATA_DIR for *.coverdata

### DIFF
--- a/plugins/eunit.mk
+++ b/plugins/eunit.mk
@@ -36,7 +36,7 @@ define eunit.erl
 	case "$(COVER)" of
 		"" -> ok;
 		_ ->
-			cover:export("eunit.coverdata")
+			cover:export("$(COVER_DATA_DIR)/eunit.coverdata")
 	end,
 	halt()
 endef
@@ -45,10 +45,10 @@ EUNIT_ERL_OPTS += -pa $(TEST_DIR) $(DEPS_DIR)/*/ebin $(APPS_DIR)/*/ebin $(CURDIR
 
 ifdef t
 ifeq (,$(findstring :,$(t)))
-eunit: test-build
+eunit: test-build cover-data-dir
 	$(gen_verbose) $(call erlang,$(call eunit.erl,['$(t)']),$(EUNIT_ERL_OPTS))
 else
-eunit: test-build
+eunit: test-build cover-data-dir
 	$(gen_verbose) $(call erlang,$(call eunit.erl,fun $(t)/0),$(EUNIT_ERL_OPTS))
 endif
 else
@@ -58,7 +58,7 @@ EUNIT_TEST_MODS = $(notdir $(basename $(call core_find,$(TEST_DIR)/,*.erl)))
 EUNIT_MODS = $(foreach mod,$(EUNIT_EBIN_MODS) $(filter-out \
 	$(patsubst %,%_tests,$(EUNIT_EBIN_MODS)),$(EUNIT_TEST_MODS)),'$(mod)')
 
-eunit: test-build $(if $(IS_APP),,apps-eunit)
+eunit: test-build $(if $(IS_APP),,apps-eunit) cover-data-dir
 	$(gen_verbose) $(call erlang,$(call eunit.erl,[$(call comma_list,$(EUNIT_MODS))]),$(EUNIT_ERL_OPTS))
 
 ifneq ($(ALL_APPS_DIRS),)

--- a/test/plugin_cover.mk
+++ b/test/plugin_cover.mk
@@ -1,6 +1,6 @@
 # Common Test plugin.
 
-COVER_CASES = ct eunit report-and-merge
+COVER_CASES = ct eunit report-and-merge custom-dir
 COVER_TARGETS = $(addprefix cover-,$(COVER_CASES))
 
 .PHONY: cover $(COVER_TARGETS)
@@ -106,3 +106,53 @@ cover-report-and-merge: build clean
 	$i "Check that the cover report is removed on distclean"
 	$t $(MAKE) -C $(APP) distclean $v
 	$t test ! -e $(APP)/cover/
+
+cover-custom-dir: build clean
+
+	$i "Bootstrap a new OTP application named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Set COVER_DATA_DIR in the Makefile"
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "COVER_DATA_DIR = custom_dir\n"}' $(APP)/Makefile
+
+	$i "Generate a module containing EUnit tests"
+	$t printf "%s\n" \
+		"-module($(APP))." \
+		"-ifdef(TEST)." \
+		"-include_lib(\"eunit/include/eunit.hrl\")." \
+		"ok_test() -> ok." \
+		"-endif." > $(APP)/src/$(APP).erl
+
+	$i "Generate a Common Test suite"
+	$t mkdir $(APP)/test
+	$t printf "%s\n" \
+		"-module($(APP)_SUITE)." \
+		"-export([all/0, ok/1])." \
+		"all() -> [ok]." \
+		"ok(_) -> ok." > $(APP)/test/$(APP)_SUITE.erl
+
+	$i "Run Common Test with code coverage enabled"
+	$t $(MAKE) -C $(APP) ct COVER=1 $v
+
+	$i "Run EUnit with code coverage enabled"
+	$t $(MAKE) -C $(APP) eunit COVER=1 $v
+
+	$i "Check that the generated file exists"
+	$t test -f $(APP)/custom_dir/ct.coverdata
+	$t test -f $(APP)/custom_dir/eunit.coverdata
+
+	$i "Merge coverdata files into all.coverdata"
+	$t $(MAKE) -C $(APP) all.coverdata $v
+	$t test -f $(APP)/custom_dir/all.coverdata
+
+	$i "Check that the generated file is removed on clean"
+	$t $(MAKE) -C $(APP) clean $v
+	$t test ! -e $(APP)/custom_dir/eunit.coverdata
+	$t test ! -e $(APP)/custom_dir/ct.coverdata
+	$t test ! -e $(APP)/custom_dir/all.coverdata
+
+	$i "Check that the custom dir is removed on distclean"
+	$t $(MAKE) -C $(APP) distclean $v
+	$t test ! -e $(APP)/custom_dir/


### PR DESCRIPTION
Also make COVER_REPORT_DIR not override user value (if set before include erlang.mk).
Use incl_app in CT cover spec.