### PR TITLE
Fix missing core-misc target in tests

### DIFF
--- a/test/core_misc.mk
+++ b/test/core_misc.mk
@@ -5,9 +5,9 @@
 CORE_MISC_CASES = clean-crash-dump distclean-tmp help without-edoc without-index without-many
 CORE_MISC_TARGETS = $(addprefix core-,$(CORE_MISC_CASES))
 
-.PHONY: $(CORE_MISC_TARGETS)
+.PHONY: core-misc $(CORE_MISC_TARGETS)
 
-core:: $(CORE_MISC_TARGETS)
+core-misc: $(CORE_MISC_TARGETS)
 
 core-clean-crash-dump: build clean
 


### PR DESCRIPTION
This updates core_misc.mk to match the other core_*.mk files, whose tests are included via the include_core mechanism in Makefile.

It's not clear to me why this would have worked for anyone or else (or the CI server), so appologies if i've missed something.

Thanks,

Tom