### PR TITLE
Fix switched UID/GID in asciidoc install

### DIFF
--- a/plugins/asciidoc.mk
+++ b/plugins/asciidoc.mk
@@ -74,7 +74,7 @@ install-docs:: install-asciidoc
 install-asciidoc: asciidoc-manual
 	$(foreach s,$(MAN_SECTIONS),\
 		mkdir -p $(MAN_INSTALL_PATH)/man$s/ && \
-		install -g `id -u` -o `id -g` -m 0644 doc/man$s/*.gz $(MAN_INSTALL_PATH)/man$s/;)
+		install -g `id -g` -o `id -u` -m 0644 doc/man$s/*.gz $(MAN_INSTALL_PATH)/man$s/;)
 
 distclean-asciidoc-manual:
 	$(gen_verbose) rm -rf $(addprefix doc/man,$(MAN_SECTIONS))


### PR DESCRIPTION
This caused the `asciidoc-install` test to fail with this message on my system, where UID != GID:

    install: cannot change ownership of 'installed/share/man3/erlang_mk.3.gz': Operation not permitted

I'm not sure why the user and group flags were there in the first place, as this looks like the default for install.

Thanks,

Tom