### PR TITLE
Added support for ASN.1 compiler option "maps".

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -108,7 +108,8 @@ define compile_asn1
 	$(verbose) mkdir -p include/
 	$(asn1_verbose) erlc -v -I include/ -o asn1/ +noobj $(ERLC_ASN1_OPTS) $(1)
 	$(verbose) mv asn1/*.erl src/
-	$(verbose) mv asn1/*.hrl include/
+	$(verbose) ls asn1/*.hrl >/dev/null 2>&1 && mv asn1/*.hrl include/ || true
+	$(verbose) $(foreach header,$(wildcard asn1/*.hrl),mv $(header) include/$(basename $(header)))
 	$(verbose) mv asn1/*.asn1db include/
 endef
 

--- a/doc/src/guide/app.asciidoc
+++ b/doc/src/guide/app.asciidoc
@@ -235,7 +235,9 @@ then built normally.
 In addition, Erlang.mk keeps track of header files (`.hrl`)
 as described at the end of this chapter. It can also compile
 C code, as described in the xref:ports[NIFs and port drivers]
-chapter.
+chapter.  Header files are not tracked under the `maps` option,
+which instructs the ASN.1 compiler to not generate any `.hrl`
+files with record definitions, but instead use maps.
 
 Erlang.mk also comes with plugins for the following formats:
 


### PR DESCRIPTION
(The option generates no include/*.hrl files, which caused an error.)

I did not alter the erlang.mk, as that seems to be intended for local overwrite only.

I have tested this on Mac OS X, which is pretty much stock Unix on this level.