### PR TITLE
.app.src.script files may return app specification directly

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -480,7 +480,10 @@ define dep_autopatch_appsrc_script.erl
 	Bindings0 = erl_eval:new_bindings(),
 	Bindings1 = erl_eval:add_binding('CONFIG', Conf0, Bindings0),
 	Bindings = erl_eval:add_binding('SCRIPT', AppSrcScript, Bindings1),
-	{ok, [Conf]} = file:script(AppSrcScript, Bindings),
+	Conf = case file:script(AppSrcScript, Bindings) of
+		{ok, [C]} -> C;
+		{ok, C} -> C
+	end,
 	ok = file:write_file(AppSrc, io_lib:format("~p.~n", [Conf])),
 	halt()
 endef


### PR DESCRIPTION
(i.e. not wrapped inside a list - rebar3 allows this as well)

for example. erlydtl's .app.src.script doesn't wrap its result in a list; without this change, autopatch fails with
```
{"init terminating in do_boot",{{badmatch,{ok,{application,erlydtl,[{description,"Django Template Language for Erlang"},{vsn,git},{modules,[]},{applications,[kernel,stdlib,compiler,syntax_tools]},{registered,[]}]}}},[{erl_eval,expr,3,[]}]}}
init terminating in do_boot ({{badmatch,{ok,{application,erlydtl,[_]}}},[{erl_eval,expr,3,[]}]})
```
This doesn't stop the build, but causes the (non-scripted) .app.src file to be used, which has an additional
dependency on merl (the .app.src.script's job is to only add that dependency if it detects an old
version of syntax_tools which doesn't include it).

rebar3 wraps a non-list value returned from a .script in a list:
https://github.com/erlang/rebar3/blob/master/src/rebar_config.erl#L290
