### PR TITLE
list templates on seperate lines

### DIFF
--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -499,4 +499,5 @@ else
 endif
 
 list-templates:
-	$(verbose) echo Available templates: $(sort $(patsubst tpl_%,%,$(filter tpl_%,$(.VARIABLES))))
+	$(verbose) @echo Available templates:
+	$(verbose) printf "    %s\n" $(sort $(patsubst tpl_%,%,$(filter tpl_%,$(.VARIABLES))))

--- a/test/plugin_bootstrap.mk
+++ b/test/plugin_bootstrap.mk
@@ -181,7 +181,7 @@ bootstrap-templates: build clean
 	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
 
 	$i "Check that we can get the list of templates"
-	$t test `$(MAKE) -C $(APP) --no-print-directory list-templates V=0 | wc -l` -eq 1
+	$t test `$(MAKE) -C $(APP) --no-print-directory list-templates V=0 | wc -l` -gt 1
 
 	$i "Generate one of each template"
 	$t $(MAKE) -C $(APP) --no-print-directory new t=gen_fsm n=my_fsm


### PR DESCRIPTION
Refactor: prettify output from `list-templates` to make it easier to read.

Example
```
$ make list-templates
Available templates:
    cowboy_http
    cowboy_loop
    cowboy_rest
    cowboy_ws
    gen_fsm
    gen_server
    gen_statem
    module
    ranch_protocol
    supervisor
```