### PR TITLE
Add relx-post-rel hook

### DIFF
--- a/plugins/relx.mk
+++ b/plugins/relx.mk
@@ -44,13 +44,22 @@ $(RELX):
 	$(verbose) chmod +x $(RELX)
 
 relx-rel: $(RELX) rel-deps app
-	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release $(if $(filter 1,$(RELX_TAR)),tar)
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release
+	$(MAKE) relx-post-rel
+ifeq ($(RELX_TAR),1)
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) tar
+endif
 
 relx-relup: $(RELX) rel-deps app
-	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release relup $(if $(filter 1,$(RELX_TAR)),tar)
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) release
+	$(MAKE) relx-post-rel
+	$(verbose) $(RELX) -c $(RELX_CONFIG) $(RELX_OPTS) relup $(if $(filter 1,$(RELX_TAR)),tar)
 
 distclean-relx-rel:
 	$(gen_verbose) rm -rf $(RELX_OUTPUT_DIR)
+
+# Default hooks.
+relx-post-rel::
 
 # Run target.
 

--- a/test/plugin_relx.mk
+++ b/test/plugin_relx.mk
@@ -53,6 +53,49 @@ relx-rel: build clean
 	$i "Check that the output directory was removed entirely"
 	$t test ! -d $(APP)/_rel/
 
+relx-post-rel: build clean
+
+	$i "Bootstrap a new release named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap bootstrap-rel $v
+
+	$i "Add relx-post-rel target to Makefile"
+	$t echo "relx-post-rel::" >> $(APP)/Makefile
+	$t echo "	echo test post rel > _rel/$(APP)_release/test_post_rel" >> $(APP)/Makefile
+	$i "Build the release"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that relx was downloaded"
+	$t test -f $(APP)/.erlang.mk/relx
+
+	$i "Check that the release was built"
+	$t test -d $(APP)/_rel
+	$t test -d $(APP)/_rel/$(APP)_release
+	$t test -f $(APP)/_rel/$(APP)_release/test_post_rel
+	$t test "test post rel" = "`cat $(APP)/_rel/$(APP)_release/test_post_rel`"
+	$t test -d $(APP)/_rel/$(APP)_release/bin
+	$t test -d $(APP)/_rel/$(APP)_release/lib
+	$t test -d $(APP)/_rel/$(APP)_release/releases
+	$t test -d $(APP)/_rel/$(APP)_release/releases/1
+
+	$i "Clean the application"
+	$t $(MAKE) -C $(APP) clean $v
+
+	$i "Check that the release still exists"
+	$t test -d $(APP)/_rel
+	$t test -d $(APP)/_rel/$(APP)_release
+	$t test -d $(APP)/_rel/$(APP)_release/bin
+	$t test -d $(APP)/_rel/$(APP)_release/lib
+	$t test -d $(APP)/_rel/$(APP)_release/releases
+	$t test -d $(APP)/_rel/$(APP)_release/releases/1
+
+	$i "Distclean the application"
+	$t $(MAKE) -C $(APP) distclean $v
+
+	$i "Check that the output directory was removed entirely"
+	$t test ! -d $(APP)/_rel/
+
 relx-bare-rel: build clean
 
 	$i "Bootstrap a new release named $(APP)"


### PR DESCRIPTION
This hook can be used, for example, to copy additional
files to release before it is tared by relx.