### PR TITLE
Set locale to `C` when checking bootstrapped app name

### DIFF
--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -411,7 +411,7 @@ ifneq ($(wildcard src/),)
 	$(error Error: src/ directory already exists)
 endif
 	$(eval p := $(PROJECT))
-	$(if $(shell echo $p | grep -x "[a-z0-9_]*"),,\
+	$(if $(shell echo $p | LC_ALL=C grep -x "[a-z0-9_]*"),,\
 		$(error Error: Invalid characters in the application name))
 	$(eval n := $(PROJECT)_sup)
 	$(verbose) $(call core_render,bs_Makefile,Makefile)
@@ -428,7 +428,7 @@ ifneq ($(wildcard src/),)
 	$(error Error: src/ directory already exists)
 endif
 	$(eval p := $(PROJECT))
-	$(if $(shell echo $p | grep -x "[a-z0-9_]*"),,\
+	$(if $(shell echo $p | LC_ALL=C grep -x "[a-z0-9_]*"),,\
 		$(error Error: Invalid characters in the application name))
 	$(verbose) $(call core_render,bs_Makefile,Makefile)
 	$(verbose) echo "include erlang.mk" >> Makefile
@@ -458,7 +458,7 @@ ifneq ($(wildcard $(APPS_DIR)/$in),)
 	$(error Error: Application $in already exists)
 endif
 	$(eval p := $(in))
-	$(if $(shell echo $p | grep -x "[a-z0-9_]*"),,\
+	$(if $(shell echo $p | LC_ALL=C grep -x "[a-z0-9_]*"),,\
 		$(error Error: Invalid characters in the application name))
 	$(eval n := $(in)_sup)
 	$(verbose) mkdir -p $(APPS_DIR)/$p/src/
@@ -477,7 +477,7 @@ ifneq ($(wildcard $(APPS_DIR)/$in),)
 	$(error Error: Application $in already exists)
 endif
 	$(eval p := $(in))
-	$(if $(shell echo $p | grep -x "[a-z0-9_]*"),,\
+	$(if $(shell echo $p | LC_ALL=C grep -x "[a-z0-9_]*"),,\
 		$(error Error: Invalid characters in the application name))
 	$(verbose) mkdir -p $(APPS_DIR)/$p/src/
 	$(verbose) $(call core_render,bs_apps_Makefile,$(APPS_DIR)/$p/Makefile)


### PR DESCRIPTION
At least on FreeBSD, the `en_US.UTF-8` locale I use breaks the check. It might be a bug on the FreeBSD 13-CURRENT I'm using, because I don't understand why it would affect the behaviour of that simple regex. Nonetheless, let's override the locale to make sure this does not happen again.