### PR TITLE
Use echo(1) instead of printf(1) in `core-autopatch-extended-erlc-opts`

### DIFF
--- a/test/core_autopatch.mk
+++ b/test/core_autopatch.mk
@@ -37,7 +37,7 @@ core-autopatch-extended-erlc-opts: init
 	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = couchbeam\n"}' $(APP)/Makefile
 
 	$i "Extend autopatch-couchbeam to add options to its ERLC_OPTS"
-	$t echo "autopatch-couchbeam:: ; printf '\nERLC_OPTS += -DWITH_JIFFY\n' >> \$$(DEPS_DIR)/couchbeam/Makefile" >> $(APP)/Makefile
+	$t echo "autopatch-couchbeam:: ; echo >> \$$(DEPS_DIR)/couchbeam/Makefile; echo 'ERLC_OPTS += -DWITH_JIFFY' >> \$$(DEPS_DIR)/couchbeam/Makefile" >> $(APP)/Makefile
 
 	$i "Build the application"
 	$t $(MAKE) -C $(APP) $v


### PR DESCRIPTION
... to create the `autopatch-couchbeam` recipe in the testcase.

Newlines characters were interpreted by echo(1) in the `core-autopatch-extended-erlc-opts` recipe which was too early: the generated recipe was malformed.

Using echo(1) and its implicit appended newline character fixes the issue.