### PR TITLE
Accept `$(force_rebuilding_dep)` to tune the behavior of `$(FULL)`

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -130,7 +130,7 @@ ifneq ($(ALL_DEPS_DIRS),)
 			:; \
 		else \
 			echo $$dep >> $(ERLANG_MK_TMP)/deps.log; \
-			if [ -z "$(strip $(FULL))" ] && [ ! -L $$dep ] && [ -f $$dep/ebin/dep_built ]; then \
+			if [ -z "$(strip $(FULL))" ] $(if $(force_rebuilding_dep),&& ($(call force_rebuilding_dep,$$dep)),) && [ ! -L $$dep ] && [ -f $$dep/ebin/dep_built ]; then \
 				:; \
 			elif [ -f $$dep/GNUmakefile ] || [ -f $$dep/makefile ] || [ -f $$dep/Makefile ]; then \
 				$(MAKE) -C $$dep IS_DEP=1; \


### PR DESCRIPTION
By default, Erlang.mk only builds dependencies once, the first time the top-level project is compiled. A forced rebuild of all dependencies can be forced by setting the `$(FULL)` variable to a non-empty value.

For developers working on the top-level project and one or more dependencies at the same time, Erlang.mk now accepts a variable/function called `$(force_rebuilding_dep)` which is called to determine if the dependency passed as the first argument should be forcibly rebuilt.

It allows a developer to filter the dependencies he works on (so they are always rebuilt) from other third-party dependencies he never touches (i.e. they are only built once at the beginning).

The content of `$(force_rebuilding_dep)` is expected to be a shell one-liner where the `$(1)` Make variable is set to the path to the dependency.

Here is an example from the testsuite:

```
force_rebuilding_dep = test '$(1)' = '$(CURDIR)/deps/cowlib'
```