### PR TITLE
Building .proto files with imports fails

### DIFF
--- a/test/plugin_protobuffs.mk
+++ b/test/plugin_protobuffs.mk
@@ -40,6 +40,38 @@ protobuffs-compile: init
 		{ok, [empty_pb, simple_pb]} = application:get_key($(APP), modules), \
 		halt()"
 
+protobuffs-compile-imports: init
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Add protobuffs to the list of dependencies"
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "BUILD_DEPS = protobuffs\n"}' $(APP)/Makefile
+
+	$i "Download two proto files with an import"
+	$t mkdir $(APP)/src/proto/
+	$t curl -s -o $(APP)/src/proto/exports.proto $(PROTOBUFFS_URL)/proto/exports.proto
+	$t curl -s -o $(APP)/src/proto/imports.proto $(PROTOBUFFS_URL)/proto/imports.proto
+
+	$i "Build the application"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that an Erlang module was generated and compiled"
+	$t test -f $(APP)/src/exports_pb.erl
+	$t test -f $(APP)/src/imports_pb.erl
+	$t test -f $(APP)/include/exports_pb.hrl
+	$t test -f $(APP)/include/imports_pb.hrl
+	$t test -f $(APP)/ebin/exports_pb.beam
+	$t test -f $(APP)/ebin/imports_pb.beam
+
+	$i "Check that the generated modules are included in .app file"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		ok = application:load($(APP)), \
+		{ok, [exports_pb, imports_pb]} = application:get_key($(APP), modules), \
+		halt()"
+
 protobuffs-compile-with-gpb: init
 
 	$i "Bootstrap a new OTP library named $(APP)"
@@ -70,6 +102,38 @@ protobuffs-compile-with-gpb: init
 	$t $(ERL) -pa $(APP)/ebin/ -eval " \
 		ok = application:load($(APP)), \
 		{ok, [empty_pb, simple_pb]} = application:get_key($(APP), modules), \
+		halt()"
+
+protobuffs-compile-imports-with-gpb: init
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Add gpb to the list of dependencies"
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "BUILD_DEPS = gpb\n"}' $(APP)/Makefile
+
+	$i "Download two proto files with an import"
+	$t mkdir $(APP)/src/proto/
+	$t curl -s -o $(APP)/src/proto/exports.proto $(PROTOBUFFS_URL)/proto/exports.proto
+	$t curl -s -o $(APP)/src/proto/imports.proto $(PROTOBUFFS_URL)/proto/imports.proto
+
+	$i "Build the application"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that an Erlang module was generated and compiled"
+	$t test -f $(APP)/src/exports_pb.erl
+	$t test -f $(APP)/src/imports_pb.erl
+	$t test -f $(APP)/include/exports_pb.hrl
+	$t test -f $(APP)/include/imports_pb.hrl
+	$t test -f $(APP)/ebin/exports_pb.beam
+	$t test -f $(APP)/ebin/imports_pb.beam
+
+	$i "Check that the generated modules are included in .app file"
+	$t $(ERL) -pa $(APP)/ebin/ -eval " \
+		ok = application:load($(APP)), \
+		{ok, [exports_pb, imports_pb]} = application:get_key($(APP), modules), \
 		halt()"
 
 protobuffs-makefile-change: init


### PR DESCRIPTION
It seems that building protobuf files that have imports on other files in the same folder fails to find the imported file. Something is wrong in the path where it looks for the imports.

I added tests for both gpb and protobuffs, and both show the same behaviour.

In fact I managed to get it to work for gpb by putting the imported file also on the projects top level, because gpb looks for `./<importfile>.proto` and it seems the `./` is top level not `src/` when it is invoked.

It's probably an easy fix, I'm just terrible with Makefiles.