### PR TITLE
Add mysql-otp to the index

### DIFF
--- a/index/mysql.mk
+++ b/index/mysql.mk
@@ -1,0 +1,7 @@
+PACKAGES += mysql
+pkg_mysql_name = mysql
+pkg_mysql_description = MySQL client library for Erlang/OTP
+pkg_mysql_homepage = https://github.com/mysql-otp/mysql-otp
+pkg_mysql_fetch = git
+pkg_mysql_repo = https://github.com/mysql-otp/mysql-otp
+pkg_mysql_commit = 1.5.1

--- a/index/mysql.mk
+++ b/index/mysql.mk
@@ -1,7 +1,0 @@
-PACKAGES += mysql
-pkg_mysql_name = mysql
-pkg_mysql_description = Erlang MySQL Driver (from code.google.com)
-pkg_mysql_homepage = https://github.com/dizzyd/erlang-mysql-driver
-pkg_mysql_fetch = git
-pkg_mysql_repo = https://github.com/dizzyd/erlang-mysql-driver
-pkg_mysql_commit = master


### PR DESCRIPTION
This PR removes the old `mysql` package and replaces it with `mysql-otp`.