### PR TITLE
plugin_dialyzer.mk: Update erlang.mk in `deps/cowlib`

### DIFF
--- a/test/plugin_dialyzer.mk
+++ b/test/plugin_dialyzer.mk
@@ -282,8 +282,9 @@ dialyzer-plt-ebin-only: init
 	$i "Build the application"
 	$t $(MAKE) -C $(APP) $v
 
-	$i "Run Cowlib tests to fetch autopatched dependencies"
-	$t $(MAKE) -C $(APP)/deps/cowlib tests $v
+	$i "Build Cowlib for tests to fetch autopatched dependencies"
+	$t cp ../erlang.mk $(APP)/deps/cowlib
+	$t $(MAKE) -C $(APP)/deps/cowlib test-build $v
 
 	$i "Run Dialyzer"
 	$t $(DIALYZER_MUTEX) $(MAKE) -C $(APP) dialyze $v


### PR DESCRIPTION
The problem is that the copy of `erlang.mk` in cowlib does not have locking in `dep_autopatch_fetch_rebar`. This triggers failures in parallel testing of Erlang.mk.

A second improvement is to just test-build cowlib instead of actually running the tests. Test deps are fetched and compiled, but we don't waste time running cowlib's testsuite.