### PR TITLE
core/test.mk: Abort build if a test file fails to compile

### DIFF
--- a/core/test.mk
+++ b/core/test.mk
@@ -47,7 +47,7 @@ endef
 ERL_TEST_FILES = $(call core_find,$(TEST_DIR)/,*.erl)
 $(ERLANG_MK_TMP)/$(PROJECT).last-testdir-build: $(ERL_TEST_FILES) $(MAKEFILE_LIST)
 	$(eval FILES_TO_COMPILE := $(if $(filter $(MAKEFILE_LIST),$?),$(filter $(ERL_TEST_FILES),$^),$?))
-	$(if $(strip $(FILES_TO_COMPILE)),$(call compile_test_erl,$(FILES_TO_COMPILE)); touch $@)
+	$(if $(strip $(FILES_TO_COMPILE)),$(call compile_test_erl,$(FILES_TO_COMPILE)) && touch $@)
 endif
 
 test-build:: IS_TEST=1

--- a/test/core_app.mk
+++ b/test/core_app.mk
@@ -2786,3 +2786,9 @@ core-app-test-build-outofdate-files-only: init
 	$t $(MAKE) -C $(APP) test-build $v
 	$t test $(APP)/test/use_blue.beam -nt $(APP)/build-2
 	$t test $(APP)/test/use_red.beam -nt $(APP)/build-2
+
+	$i "Add a syntax error to the test; check that the build fails"
+	$t $(SLEEP)
+	$t echo "garbage" >> $(APP)/test/use_blue.erl
+	$t ! $(MAKE) -C $(APP) test-build $v
+	$t ! test -f $(APP)/test/use_blue.beam


### PR DESCRIPTION
In commit c55d0dcd6182983521d4ab34478cfe4b093edb12, the recipe was improved to only rebuild out-of-date test files (not everything as it was the case before).

However in the process, the exit status of the Erlang compiler was not checked anymore, leading to build failures in the test directory to be ignored. This patch fixes this bug.