### PR TITLE
plugins/concuerror.mk: Use $(MAKE) instead of hard-coding `make`

### DIFF
--- a/plugins/concuerror.mk
+++ b/plugins/concuerror.mk
@@ -22,7 +22,7 @@ endif
 
 $(ERLANG_MK_TMP)/Concuerror/bin/concuerror: | $(ERLANG_MK_TMP)
 	$(verbose) git clone https://github.com/parapluu/Concuerror $(ERLANG_MK_TMP)/Concuerror
-	$(verbose) make -C $(ERLANG_MK_TMP)/Concuerror
+	$(verbose) $(MAKE) -C $(ERLANG_MK_TMP)/Concuerror
 
 $(CONCUERROR_LOGS_DIR):
 	$(verbose) mkdir -p $(CONCUERROR_LOGS_DIR)


### PR DESCRIPTION
This fixes the plugin when e.g. GNU Make is installed as `gmake` (and `make` is another incompatible implementation).