### PR TITLE
Issue 894 (Darwin and NIFs)

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -549,6 +549,15 @@ define dep_autopatch_rebar.erl
 				false -> [];
 				{_, PortEnv0} -> FilterEnv(PortEnv0)
 			end,
+			SharedFlag = fun
+							([],_) -> "\n";
+							(Ext,darwin) ->
+								case lists:member(Ext,[".so",".dylib"]) of
+									true -> " -shared\n";
+									_ -> "\n"
+								end;
+							(_,_) -> " -shared\n"
+						end,
 			PortSpec = fun ({Output, Input0, Env}) ->
 				filelib:ensure_dir("$(call core_native_path,$(DEPS_DIR)/$1/)" ++ Output),
 				Input = [[" ", I] || I <- Input0],
@@ -567,11 +576,7 @@ define dep_autopatch_rebar.erl
 					Output, ": $$\(foreach ext,.c .C .cc .cpp,",
 						"$$\(patsubst %$$\(ext),%.o,$$\(filter %$$\(ext),$$\(wildcard", Input, "))))\n",
 					"\t$$\(CC) -o $$\@ $$\? $$\(LDFLAGS) $$\(ERL_LDFLAGS) $$\(DRV_LDFLAGS) $$\(EXE_LDFLAGS)",
-					case {filename:extension(Output), $(PLATFORM)} of
-					    {[], _} -> "\n";
-					    {_, darwin} -> "\n";
-					    _ -> " -shared\n"
-					end])
+					SharedFlag(filename:extension(Output), $(PLATFORM))])
 			end,
 			[PortSpec(S) || S <- PortSpecs]
 	end,

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -550,9 +550,9 @@ define dep_autopatch_rebar.erl
 				{_, PortEnv0} -> FilterEnv(PortEnv0)
 			end,
 			SharedFlag = fun
-							([],_) -> "\n";
+              ([],_) -> "\n";
 							(Ext,darwin) ->
-								case lists:member(Ext,[".so",".dylib"]) of
+							  case lists:member(Ext,[".so",".dylib"]) of
 									true -> " -shared\n";
 									_ -> "\n"
 								end;

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -550,14 +550,14 @@ define dep_autopatch_rebar.erl
 				{_, PortEnv0} -> FilterEnv(PortEnv0)
 			end,
 			SharedFlag = fun
-              ([],_) -> "\n";
-							(Ext,darwin) ->
-							  case lists:member(Ext,[".so",".dylib"]) of
-									true -> " -shared\n";
-									_ -> "\n"
-								end;
-							(_,_) -> " -shared\n"
-						end,
+                            ([],_) -> "\n";
+                            (Ext,darwin) ->
+                              case lists:member(Ext,[".so",".dylib"]) of
+                                true -> " -shared\n";
+                                _ -> "\n"
+                              end;
+                            (_,_) -> " -shared\n"
+                        end,
 			PortSpec = fun ({Output, Input0, Env}) ->
 				filelib:ensure_dir("$(call core_native_path,$(DEPS_DIR)/$1/)" ++ Output),
 				Input = [[" ", I] || I <- Input0],


### PR DESCRIPTION
When the platform is darwin, SharedFlag compares the extensions of filename
to determine whether to add "-shared" or not
Fixes #894 