### PR TITLE
Fix `query-deps` for projects without deps

### DIFF
--- a/core/deps-tools.mk
+++ b/core/deps-tools.mk
@@ -63,6 +63,7 @@ $(ERLANG_MK_RECURSIVE_SHELL_DEPS_LIST): | $(ERLANG_MK_TMP)
 ifeq ($(IS_APP)$(IS_DEP),)
 	$(verbose) rm -f $(ERLANG_MK_RECURSIVE_TMP_LIST)
 endif
+	$(verbose) touch $(ERLANG_MK_RECURSIVE_TMP_LIST)
 	$(verbose) set -e; for dep in $^ ; do \
 		if ! grep -qs ^$$dep$$ $(ERLANG_MK_RECURSIVE_TMP_LIST); then \
 			echo $$dep >> $(ERLANG_MK_RECURSIVE_TMP_LIST); \


### PR DESCRIPTION
To reproduce:

```
git clone https://github.com/rabbitmq/inet_tcp_proxy.git
cd inet_tcp_proxy
$ make BRANCH=master QUERY='name fetch_method repo version absolute_path' query-deps
/bin/sh: /home/lbakken/development/rabbitmq/umbrella/deps/inet_tcp_proxy/.erlang.mk/recursive-tmp-deps-231462.log: No such file or directory
rm: cannot remove '/home/lbakken/development/rabbitmq/umbrella/deps/inet_tcp_proxy/.erlang.mk/recursive-tmp-deps-231462.log': No such file or directory
make: *** [erlang.mk:7642: /home/lbakken/development/rabbitmq/umbrella/deps/inet_tcp_proxy/.erlang.mk/recursive-deps-list.log] Error 1
```