### PR TITLE
fix rebar dependency specification

### DIFF
--- a/core/compat.mk
+++ b/core/compat.mk
@@ -23,7 +23,7 @@ define compat_rebar_config
 $(call comma_list,$(foreach d,$(DEPS),\
 	$(if $(filter hex,$(call dep_fetch,$d)),\
 		{$(call dep_name,$d)$(comma)"$(call dep_repo,$d)"},\
-		{$(call dep_name,$d)$(comma)".*"$(comma){git,"$(call dep_repo,$d)"$(comma)"$(call dep_commit,$d)"}})))
+		{$(call dep_name,$d)$(comma)".*"$(comma){git,"$(call dep_repo,$d)"$(comma){ref,"$(call dep_commit,$d)"}}})))
 ]}.
 {erl_opts, $(call compat_erlc_opts_to_list,$(ERLC_OPTS))}.
 endef

--- a/test/core_compat.mk
+++ b/test/core_compat.mk
@@ -111,7 +111,7 @@ core-compat-rebar-deps-git: init
 	$i "Check that Cowboy is listed in rebar.config"
 	$t $(ERL) -eval " \
 		{ok, C} = file:consult(\"$(APP)/rebar.config\"), \
-		{_, [{cowboy, _, {git, _, \"1.0.0\"}}]} = lists:keyfind(deps, 1, C), \
+		{_, [{cowboy, _, {git, _, {ref,\"1.0.0\"}}}]} = lists:keyfind(deps, 1, C), \
 		halt()"
 
 	$i "Distclean the application"


### PR DESCRIPTION
Rebar3 emits a warning for "raw" git dependency versions, and expects a
tuple indicating what the version actually is (a branch, tag or ref).

This warning propagates to any software directly or indirectly using
Gun.

This syntax also works with rebar2
(https://github.com/rebar/rebar/blob/master/src/rebar_deps.erl#L608).