### PR TITLE
An attempt to optionally use the compile server in erlc.

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -89,14 +89,17 @@ define app_file
 endef
 endif
 
+ifneq ($(ERLC_USE_SERVER), true)
 app-build: ebin/$(PROJECT).app
 	$(verbose) :
+endif
 
 # Source files.
 
 ALL_SRC_FILES := $(sort $(call core_find,src/,*))
 
 ERL_FILES := $(filter %.erl,$(ALL_SRC_FILES))
+ORIG_ERL_FILES := $(ERL_FILES)
 CORE_FILES := $(filter %.core,$(ALL_SRC_FILES))
 
 # ASN.1 files.
@@ -328,6 +331,7 @@ ebin/%.beam: src/%.erl
 ERL_BEAM_FILES += $(patsubst src/%.erl, ebin/%.beam, $(ERL_FILES))
 
 app:: $(ERL_BEAM_FILES)
+app-build: ebin/$(PROJECT).app $(ERL_BEAM_FILES)
 endif
 
 ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.src)

--- a/plugins/eunit.mk
+++ b/plugins/eunit.mk
@@ -42,7 +42,7 @@ eunit: test-build cover-data-dir
 	$(gen_verbose) $(call erlang,$(call eunit.erl,fun $(t)/0),$(EUNIT_ERL_OPTS))
 endif
 else
-EUNIT_EBIN_MODS = $(notdir $(basename $(ERL_FILES) $(BEAM_FILES)))
+EUNIT_EBIN_MODS = $(notdir $(basename $(ORIG_ERL_FILES) $(BEAM_FILES)))
 EUNIT_TEST_MODS = $(notdir $(basename $(call core_find,$(TEST_DIR)/,*.erl)))
 
 EUNIT_MODS = $(foreach mod,$(EUNIT_EBIN_MODS) $(filter-out \


### PR DESCRIPTION
We use the env var ERLC_USE_SERVER to control the behaviour, since
erlc already uses that variable.

Although this seems to work fine for our project, I am not sure that
it works correctly with files generated from .yrl etc.