### PR TITLE
Add COVER_EXCL_MODS variable

### DIFF
--- a/doc/src/guide/coverage.asciidoc
+++ b/doc/src/guide/coverage.asciidoc
@@ -46,6 +46,17 @@ some applications by defining the `COVER_APPS` variable:
 [source,make]
 COVER_APPS = presence backend
 
+=== Removing modules from the cover report
+
+By default Erlang.mk will include all modules in the
+cover report.
+
+To exclude some modules from the report, you can
+define the `COVER_EXCLUDE_MODS` variable:
+
+[source,make]
+COVER_EXCLUDE_MODS = cowboy_app cowboy_sup
+
 === Configuring paths
 
 By default Erlang.mk will store 'coverdata' files and

--- a/test/plugin_cover.mk
+++ b/test/plugin_cover.mk
@@ -150,6 +150,35 @@ endif
 	$t test -f $(APP)/logs/ct_run.*/cow_http_hd.COVER.html
 	$t ! test -e $(APP)/logs/ct_run.*/ranch_app.COVER.html
 
+cover-ct-excl-mods: init
+
+	$i "Bootstrap a new OTP application named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap $v
+
+	$i "Add supervisor module to the cover exclude module list "
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "COVER_EXCLUDE_MODS = $(APP)_sup  \n"}' $(APP)/Makefile
+
+	$i "Generate a Common Test suite"
+	$t mkdir $(APP)/test
+	$t printf "%s\n" \
+		"-module($(APP)_SUITE)." \
+		"-export([all/0, ok/1])." \
+		"all() -> [ok]." \
+		"ok(_) -> application:start($(APP))." > $(APP)/test/$(APP)_SUITE.erl
+
+	$i "Run Common Test with code coverage enabled"
+	$t $(MAKE) -C $(APP) ct COVER=1 $v
+
+	$i "Check that the generated files exist"
+	$t test -f $(APP)/cover/ct.coverdata
+	$t test -f $(APP)/test/ct.cover.spec
+
+	$i "Check that the supervisor module is not included in the cover report"
+	$t ! test -e $(APP)/logs/ct_run.*/$(APP)_sup.COVER.html
+
+
 cover-custom-dir: init
 
 	$i "Bootstrap a new OTP application named $(APP)"
@@ -383,6 +412,34 @@ endif
 	$t test -f $(APP)/cover/cowboy_app.COVER.html
 	$t test -f $(APP)/cover/cow_http_hd.COVER.html
 	$t ! test -e $(APP)/cover/ranch_app.COVER.html
+
+cover-eunit-excl-mods: init
+
+	$i "Bootstrap a new OTP application named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap $v
+
+	$i "Add supervisor module to the cover exclude module list "
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "COVER_EXCLUDE_MODS = $(APP)_sup  \n"}' $(APP)/Makefile
+
+	$i "Generate a module containing EUnit tests"
+	$t printf "%s\n" \
+		"-module($(APP))." \
+		"-ifdef(TEST)." \
+		"-include_lib(\"eunit/include/eunit.hrl\")." \
+		"ok_test() -> application:ensure_all_started($(APP))." \
+		"-endif." > $(APP)/src/$(APP).erl
+
+	$i "Run EUnit with code coverage enabled"
+	$t $(MAKE) -C $(APP) eunit COVER=1 $v
+
+	$i "Build the cover report"
+	$t $(MAKE) -C $(APP) cover-report $v
+
+	$i "Check that app was covered, but supervisor wasn't"
+	$t test -f $(APP)/cover/$(APP)_app.COVER.html
+	$t ! test -e $(APP)/cover/$(APP)_sup.COVER.html
 
 cover-proper: init
 


### PR DESCRIPTION
I added support for excluding modules from the cover report through a variable called COVER_EXCL_MODS.
Added tests and updated documentation.