### PR TITLE
Add dep version in examples in README and user guide

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,6 +9,7 @@ Embrace the power and simplicity of Makefiles.
 [source,make]
 PROJECT = webchat
 DEPS = cowboy
+dep_cowboy_commit = 2.8.0
 include erlang.mk
 
 http://erlang.mk/guide/getting_started.html[Get started]

--- a/doc/src/guide/deps.asciidoc
+++ b/doc/src/guide/deps.asciidoc
@@ -49,6 +49,15 @@ fetch and compile Cowboy. Erlang.mk will also ensure Cowboy
 is available whenever you use the shell, run tests and any
 other operations.
 
+Note though that you may need to specify the version of a
+dependency to use. Otherwise, you may get an outdated version,
+since the package index used by Erlang.mk is not always
+updated with the latest version of each package.
+
+[source,make]
+DEPS = cowboy
+dep_cowboy_commit = 2.8.0
+
 Erlang.mk will fill in the application resource file with
 all applications found in `DEPS`. But not all dependencies
 are Erlang applications, and not all dependencies need to


### PR DESCRIPTION
Add dep_cowboy_commit 2.8.0 and a note in the user guide
dependencies section that the versions in the package index
are not always up to date.