### PR TITLE
docs(edoc): recursively find source paths

### DIFF
--- a/plugins/edoc.mk
+++ b/plugins/edoc.mk
@@ -11,7 +11,11 @@ EDOC_OUTPUT ?= doc
 
 define edoc.erl
 	SrcPaths = lists:foldl(fun(P, Acc) ->
-		filelib:wildcard(atom_to_list(P) ++ "/{src,c_src}") ++ Acc
+		filelib:wildcard(atom_to_list(P) ++ "/{src,c_src}")
+		++ lists:filter(fun(D) ->
+			filelib:is_dir(D)
+		end, filelib:wildcard(atom_to_list(P) ++ "/{src,c_src}/**"))
+		++ Acc
 	end, [], [$(call comma_list,$(patsubst %,'%',$(call core_native_path,$(EDOC_SRC_DIRS))))]),
 	DefaultOpts = [{dir, "$(EDOC_OUTPUT)"}, {source_path, SrcPaths}, {subpackages, false}],
 	edoc:application($(1), ".", [$(2)] ++ DefaultOpts),

--- a/test/plugin_edoc.mk
+++ b/test/plugin_edoc.mk
@@ -132,3 +132,66 @@ edoc-src-dirs: init
 	$t test -f $(APP)/doc/$(APP)_sup.html
 	$t test -f $(APP)/doc/my_app_app.html
 	$t test -f $(APP)/doc/my_app_sup.html
+
+edoc-src-subdirs: init
+
+	$i "Bootstrap a new OTP application named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap $v
+
+	$i "Add current directory to the list of EDoc source directories"
+	$t echo 'EDOC_SRC_DIRS = $$(CURDIR)' >> $(APP)/Makefile
+
+	$i "Generate a module in a subdirectory with EDoc comments"
+	$t mkdir $(APP)/src/subdir/
+	$t printf "%s\n" \
+		"%% @doc erlang-mk-edoc-subdir-module" \
+		"-module($(APP))." \
+		"-export([ok/0])." \
+		"" \
+		"%% @doc erlang-mk-edoc-subdir-function" \
+		"ok() -> ok." > $(APP)/src/subdir/$(APP).erl
+
+	$i "Run EDoc"
+	$t $(MAKE) -C $(APP) edoc $v
+
+	$i "Check that the new module's documentation was generated"
+	$t test -f $(APP)/doc/$(APP).html
+
+	$i "Check that the EDoc comments are in the generated documentation"
+	$t grep -q erlang-mk-edoc-subdir-module $(APP)/doc/$(APP).html
+	$t grep -q erlang-mk-edoc-subdir-function $(APP)/doc/$(APP).html
+
+edoc-src-multiapp-subdirs: init
+
+	$i "Bootstrap a multi application repository with a root application"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap $v
+
+	$i "Create a new application my_app"
+	$t $(MAKE) -C $(APP) new-app in=my_app $v
+
+	$i "Add apps directories to the list of EDoc source directories"
+	$t echo 'EDOC_SRC_DIRS = $$(ALL_APPS_DIRS)' >> $(APP)/Makefile
+
+	$i "Generate a module in a subdirectory with EDoc comments"
+	$t mkdir $(APP)/apps/my_app/src/subdir/
+	$t printf "%s\n" \
+		"%% @doc erlang-mk-edoc-subdir-module" \
+		"-module($(APP))." \
+		"-export([ok/0])." \
+		"" \
+		"%% @doc erlang-mk-edoc-subdir-function" \
+		"ok() -> ok." > $(APP)/apps/my_app/src/subdir/$(APP).erl
+
+	$i "Run EDoc"
+	$t $(MAKE) -C $(APP) edoc $v
+
+	$i "Check that the new module's documentation was generated"
+	$t test -f $(APP)/doc/$(APP).html
+
+	$i "Check that the EDoc comments are in the generated documentation"
+	$t grep -q erlang-mk-edoc-subdir-module $(APP)/doc/$(APP).html
+	$t grep -q erlang-mk-edoc-subdir-function $(APP)/doc/$(APP).html


### PR DESCRIPTION
Subdirectories of `src` are correctly used when compiling, so they should also be considered when generating `edoc`.