### PR TITLE
Replace erlang:get_stacktrace() with catch C:E:S

### DIFF
--- a/plugins/asciidoc.mk
+++ b/plugins/asciidoc.mk
@@ -57,8 +57,8 @@ try
 		})
 	end || F <- [$(shell echo $(addprefix $(comma)\",$(addsuffix \",$1)) | sed 's/^.//')]],
 	halt(0)
-catch C:E ->
-	io:format("Exception ~p:~p~nStacktrace: ~p~n", [C, E, erlang:get_stacktrace()]),
+catch C:E$(if $V,:S) ->
+	io:format("Exception: ~p:~p~n$(if $V,Stacktrace: ~p~n)", [C, E$(if $V,$(comma) S)]),
 	halt(1)
 end.
 endef

--- a/plugins/proper.mk
+++ b/plugins/proper.mk
@@ -37,8 +37,8 @@ define proper_check.erl
 	end of
 		true -> halt(0);
 		_ -> halt(1)
-	catch error:undef ->
-		io:format("Undefined property or module?~n~p~n", [erlang:get_stacktrace()]),
+	catch error:undef$(if $V,:Stacktrace) ->
+		io:format("Undefined property or module?~n$(if $V,~p~n)", [$(if $V,Stacktrace)]),
 		halt(0)
 	end.
 endef

--- a/plugins/triq.mk
+++ b/plugins/triq.mk
@@ -26,8 +26,8 @@ define triq_check.erl
 	end of
 		true -> halt(0);
 		_ -> halt(1)
-	catch error:undef ->
-		io:format("Undefined property or module?~n~p~n", [erlang:get_stacktrace()]),
+	catch error:undef$(if $V,:Stacktrace) ->
+		io:format("Undefined property or module?~n$(if $V,~p~n)", [$(if $V,Stacktrace)]),
 		halt(0)
 	end.
 endef


### PR DESCRIPTION
`erlang:get_stacktrace()` will be removed in OTP 24.