### PR TITLE
fixes some broken test cases

### DIFF
--- a/test/core_app.mk
+++ b/test/core_app.mk
@@ -2766,7 +2766,7 @@ core-app-test-build-outofdate-files-only: init
 	$t $(SLEEP)
 	$t touch $(APP)/build-1
 
-	$i "Re-un the make command; check that nothing is rebuilt"
+	$i "Re-run the make command; check that nothing is rebuilt"
 	$t $(MAKE) -C $(APP) test-build $v
 	$t test $(APP)/test/use_blue.beam -ot $(APP)/build-1
 	$t test $(APP)/test/use_red.beam -ot $(APP)/build-1

--- a/test/core_deps.mk
+++ b/test/core_deps.mk
@@ -623,34 +623,36 @@ endif
 		{ok, \"1.0.0\"} = application:get_key(cowboy, vsn), \
 		halt()"
 
-core-deps-fetch-hg: init
+## Need another mercurial repo!
 
-	$i "Bootstrap a new OTP library named $(APP)"
-	$t mkdir $(APP)/
-	$t cp ../erlang.mk $(APP)/
-	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+# core-deps-fetch-hg: init
 
-	$i "Add Ehsa 4.0.3 to the list of dependencies"
-	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = ehsa\ndep_ehsa = hg https://bitbucket.org/a12n/ehsa 4.0.3\n"}' $(APP)/Makefile
+# 	$i "Bootstrap a new OTP library named $(APP)"
+# 	$t mkdir $(APP)/
+# 	$t cp ../erlang.mk $(APP)/
+# 	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
 
-ifdef LEGACY
-	$i "Add ehsa to the applications key in the .app.src file"
-	$t perl -ni.bak -e 'print;if ($$.==7) {print "\t\tehsa,\n"}' $(APP)/src/$(APP).app.src
-endif
+# 	$i "Add Ehsa 4.0.3 to the list of dependencies"
+# 	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = ehsa\ndep_ehsa = hg https://bitbucket.org/a12n/ehsa 4.0.3\n"}' $(APP)/Makefile
 
-	$i "Build the application"
-	$t $(MAKE) -C $(APP) $v
+# ifdef LEGACY
+# 	$i "Add ehsa to the applications key in the .app.src file"
+# 	$t perl -ni.bak -e 'print;if ($$.==7) {print "\t\tehsa,\n"}' $(APP)/src/$(APP).app.src
+# endif
 
-	$i "Check that all dependencies were fetched"
-	$t test -d $(APP)/deps/ehsa
+# 	$i "Build the application"
+# 	$t $(MAKE) -C $(APP) $v
 
-	$i "Check that the application was compiled correctly"
-	$t $(ERL) -pa $(APP)/ebin/ $(APP)/deps/*/ebin/ -eval " \
-		[ok = application:load(App) || App <- [$(APP), ehsa]], \
-		{ok, Deps} = application:get_key($(APP), applications), \
-		true = lists:member(ehsa, Deps), \
-		{ok, \"4.0.3\"} = application:get_key(ehsa, vsn), \
-		halt()"
+# 	$i "Check that all dependencies were fetched"
+# 	$t test -d $(APP)/deps/ehsa
+
+# 	$i "Check that the application was compiled correctly"
+# 	$t $(ERL) -pa $(APP)/ebin/ $(APP)/deps/*/ebin/ -eval " \
+# 		[ok = application:load(App) || App <- [$(APP), ehsa]], \
+# 		{ok, Deps} = application:get_key($(APP), applications), \
+# 		true = lists:member(ehsa, Deps), \
+# 		{ok, \"4.0.3\"} = application:get_key(ehsa, vsn), \
+# 		halt()"
 
 # Legacy must fail for the top-level application, but work for dependencies.
 core-deps-fetch-legacy: init

--- a/test/core_query.mk
+++ b/test/core_query.mk
@@ -145,6 +145,8 @@ endif
 	$i "Query the dependencies of $(APP)"
 	$t $(MAKE) -C $(APP) query-deps $v
 
+	$(eval COWLIB_MASTER_VSN := $(shell curl -s https://raw.githubusercontent.com/ninenines/gun/master/Makefile | awk '/dep_cowlib/ {print $$5}'))
+
 	$i "Confirm that the expected applications were found"
 	$t printf "%s\n" \
 		"$(APP): cowboy git https://github.com/ninenines/cowboy 2.7.0" \
@@ -154,7 +156,7 @@ endif
 		"farwest: cowlib git https://github.com/ninenines/cowlib master" \
 		"farwest: cowboy git https://github.com/ninenines/cowboy master" \
 		"farwest: gun git https://github.com/ninenines/gun master" \
-		"gun: cowlib git https://github.com/ninenines/cowlib 2.9.0" \
+		"gun: cowlib git https://github.com/ninenines/cowlib $(COWLIB_MASTER_VSN)" \
 		> $(APP)/expected-deps.txt
 	$t cmp $(APP)/expected-deps.txt $(APP)/.erlang.mk/query-deps.log
 


### PR DESCRIPTION
it seems that some test cases are broken; here's an attempt at one fix and skipping of one (since bitbucket has moved to github).

while I was doing this, I noticed that one test (`core-app-test-build-outofdate-files-only`) fails intermittently on my machine (pretty standard ubuntu).  the problem is that after adding "garbage" to `use_blue.erl`, erlang.mk doesn't try to rebuild the beam.  if I add  a sleep 1 it always works.

here's what it looks like when the test has failed:
```
$ ls --full-time test
total 16
-rw-rw-r-- 1 mbj mbj 884 2020-11-27 10:29:47.981557626 +0100 use_blue.beam
-rw-rw-r-- 1 mbj mbj  27 2020-11-27 10:29:47.985557207 +0100 use_blue.erl
-rw-rw-r-- 1 mbj mbj 884 2020-11-27 10:29:47.981557626 +0100 use_red.beam
-rw-rw-r-- 1 mbj mbj  18 2020-11-27 10:29:46.813679953 +0100 use_red.erl
$ make test-build 
 APP    test_core_app_test_build_outofdate_files_only
 GEN    test-build
$ ls --full-time test
total 16
-rw-rw-r-- 1 mbj mbj 884 2020-11-27 10:29:47.981557626 +0100 use_blue.beam
-rw-rw-r-- 1 mbj mbj  27 2020-11-27 10:29:47.985557207 +0100 use_blue.erl
-rw-rw-r-- 1 mbj mbj 884 2020-11-27 10:29:47.981557626 +0100 use_red.beam
-rw-rw-r-- 1 mbj mbj  18 2020-11-27 10:29:46.813679953 +0100 use_red.erl
```
