### PR TITLE
Add sleep to test cases, if needed

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -46,6 +46,8 @@ endif
 
 ifeq ($(shell touch a; sleep 0.01; touch b; sleep 0.01; touch c; test c -nt b -a b -nt a; echo $$?; rm a b c),1)
 SLEEP = sleep 1
+else ifeq ($(shell touch a; touch b; touch c; test c -nt b -a b -nt a; echo $$?; rm a b c),1)
+SLEEP = sleep 0.01
 else
 SLEEP =
 endif


### PR DESCRIPTION
Try do detect if we need to sleep in tests between a build and when a
source file is modified.  Without a sleep the source file and the
target may get the same modification time, on some machines.