### PR TITLE
Introduce LOCAL_BUILD_DEPS and LOCAL_TEST_DEPS

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -104,7 +104,7 @@ dep_name = $(call query_name,$(1))
 dep_repo = $(call query_repo_git,$(1))
 dep_commit = $(if $(dep_$(1)_commit),$(dep_$(1)_commit),$(if $(dep_$(1)),$(if $(filter hex,$(word 1,$(dep_$(1)))),$(word 2,$(dep_$(1))),$(word 3,$(dep_$(1)))),$(pkg_$(1)_commit)))
 
-LOCAL_DEPS_DIRS = $(foreach a,$(LOCAL_DEPS),$(if $(wildcard $(APPS_DIR)/$(a)),$(APPS_DIR)/$(a)))
+LOCAL_DEPS_DIRS = $(foreach a,$(LOCAL_BUILD_DEPS) $(LOCAL_DEPS),$(if $(wildcard $(APPS_DIR)/$(a)),$(APPS_DIR)/$(a)))
 ALL_DEPS_DIRS = $(addprefix $(DEPS_DIR)/,$(foreach dep,$(filter-out $(IGNORE_DEPS),$(BUILD_DEPS) $(DEPS)),$(call dep_name,$(dep))))
 
 # When we are calling an app directly we don't want to include it here

--- a/core/test.mk
+++ b/core/test.mk
@@ -7,7 +7,7 @@
 
 TEST_DIR ?= $(CURDIR)/test
 
-ALL_TEST_DEPS_DIRS = $(addprefix $(DEPS_DIR)/,$(TEST_DEPS))
+ALL_TEST_DEPS_DIRS = $(addprefix $(APPS_DIR)/,$(LOCAL_TEST_DEPS)) $(addprefix $(DEPS_DIR)/,$(TEST_DEPS))
 
 TEST_ERLC_OPTS ?= +debug_info +warn_export_vars +warn_shadow_vars +warn_obsolete_guard
 TEST_ERLC_OPTS += -DTEST=1


### PR DESCRIPTION
`LOCAL_BUILD_DEPS` is the equivalent of `BUILD_DEPS` for local deps in `APPS_DIR`

`LOCAL_TEST_DEPS` is the equivalent of `TEST_DEPS` for local deps in `APPS_DIR`

Something that I noticed which working on this is that `APPS_DIR` and `DEPS_DIR` always end up in the `ERL_LIBS`. So, these values don't affect what's on the code path when tests run. They simply imply a compilation order.