### PR TITLE
Removed hardcoded `-arch x86_64` for MacOS nifs

### DIFF
--- a/plugins/c_src.mk
+++ b/plugins/c_src.mk
@@ -35,9 +35,9 @@ ifeq ($(PLATFORM),msys2)
 	CXXFLAGS ?= -O3 -finline-functions -Wall
 else ifeq ($(PLATFORM),darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -Wall
+	LDFLAGS ?= -flat_namespace -undefined suppress
 else ifeq ($(PLATFORM),freebsd)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes


### PR DESCRIPTION
Just checked git blame and this flag seems to have been there from the very beginning (powerpc remenant?). For current macs the flag seems problematic as it overrides the default choice of building for the current architecture and hence prevents building on ARM based macs.