### PR TITLE
Handle missing app.src file

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -649,7 +649,10 @@ endef
 define dep_autopatch_appsrc_script.erl
 	AppSrc = "$(call core_native_path,$(DEPS_DIR)/$1/src/$1.app.src)",
 	AppSrcScript = AppSrc ++ ".script",
-	{ok, Conf0} = file:consult(AppSrc),
+	case file:consult(AppSrc) of
+		{error, enoent} -> halt();
+		_ -> ok
+	end,
 	Bindings0 = erl_eval:new_bindings(),
 	Bindings1 = erl_eval:add_binding('CONFIG', Conf0, Bindings0),
 	Bindings = erl_eval:add_binding('SCRIPT', AppSrcScript, Bindings1),


### PR DESCRIPTION
Prevents a `badmatch` crash. You can see the case where this happens when building `hexpm-cli`. `V=2` output is attached:

[hexpm-make.txt](https://github.com/ninenines/erlang.mk/files/8501847/hexpm-make.txt)
