### PR TITLE
Update RabbitMQ specific packages

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -767,20 +767,11 @@ endif
 
 autopatch-$(call dep_name,$1)::
 	$(verbose) if [ "$(1)" = "amqp_client" -a "$(RABBITMQ_CLIENT_PATCH)" ]; then \
-		if [ ! -d $(DEPS_DIR)/rabbitmq-codegen ]; then \
-			echo " PATCH  Downloading rabbitmq-codegen"; \
-			git clone https://github.com/rabbitmq/rabbitmq-codegen.git $(DEPS_DIR)/rabbitmq-codegen; \
-		fi; \
 		if [ ! -d $(DEPS_DIR)/rabbitmq-server ]; then \
 			echo " PATCH  Downloading rabbitmq-server"; \
 			git clone https://github.com/rabbitmq/rabbitmq-server.git $(DEPS_DIR)/rabbitmq-server; \
 		fi; \
 		ln -s $(DEPS_DIR)/amqp_client/deps/rabbit_common-0.0.0 $(DEPS_DIR)/rabbit_common; \
-	elif [ "$(1)" = "rabbit" -a "$(RABBITMQ_SERVER_PATCH)" ]; then \
-		if [ ! -d $(DEPS_DIR)/rabbitmq-codegen ]; then \
-			echo " PATCH  Downloading rabbitmq-codegen"; \
-			git clone https://github.com/rabbitmq/rabbitmq-codegen.git $(DEPS_DIR)/rabbitmq-codegen; \
-		fi \
 	elif [ "$1" = "elixir" -a "$(ELIXIR_PATCH)" ]; then \
 		ln -s lib/elixir/ebin $(DEPS_DIR)/elixir/; \
 	else \

--- a/index/amqp_client.mk
+++ b/index/amqp_client.mk
@@ -3,5 +3,5 @@ pkg_amqp_client_name = amqp_client
 pkg_amqp_client_description = RabbitMQ Erlang AMQP client
 pkg_amqp_client_homepage = https://www.rabbitmq.com/erlang-client-user-guide.html
 pkg_amqp_client_fetch = git
-pkg_amqp_client_repo = https://github.com/rabbitmq/rabbitmq-erlang-client.git
-pkg_amqp_client_commit = master
+pkg_amqp_client_repo = https://github.com/rabbitmq/rabbitmq-server.git
+pkg_amqp_client_commit = main

--- a/index/rabbit.mk
+++ b/index/rabbit.mk
@@ -4,4 +4,4 @@ pkg_rabbit_description = RabbitMQ Server
 pkg_rabbit_homepage = https://www.rabbitmq.com/
 pkg_rabbit_fetch = git
 pkg_rabbit_repo = https://github.com/rabbitmq/rabbitmq-server.git
-pkg_rabbit_commit = master
+pkg_rabbit_commit = main


### PR DESCRIPTION
My guess is that these changes will not work out of the box and I will need assistance from @essen

`amqp_client` moved from its own repository to this location:

https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/amqp_client

Related to https://github.com/rabbitmq/rabbitmq-metronome/issues/16