### PR TITLE
Add Common Test Sub Group example

### DIFF
--- a/doc/src/guide/common_test.asciidoc
+++ b/doc/src/guide/common_test.asciidoc
@@ -99,5 +99,11 @@ the test suite does not group test cases:
 [source,bash]
 $ make ct-http c=headers_dupe
 
+A test within a specific subgroup can be run by providing a
+group path:
+
+[source,bash]
+$ make ct-http t=[top_level_group,second_level_group,third_level_group]:my_case
+
 Finally, xref:coverage[code coverage] is available,
 but covered in its own chapter.


### PR DESCRIPTION
> With this type of specification execution of unwanted groups (in otherwise matching paths), and/or the execution of subgroups can be avoided. The command line syntax of the group path is a list of group names in the path

https://www.erlang.org/doc/apps/common_test/run_test_chapter.html#test-case-group-execution