### PR TITLE
Allow git + hex deps to be cached

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -687,13 +687,15 @@ define dep_autopatch_appsrc.erl
 	halt()
 endef
 
+ifeq ($(CACHE_DEPS),1)
+
 define __fetch_git
 	mkdir -p $(CACHE_DIR)/gits; \
 	if test -d "$(join $(CACHE_DIR)/gits/,$(call dep_name,$(1)))"; then \
 		cd $(join $(CACHE_DIR)/gits/,$(call dep_name,$(1))); \
 		if ! git checkout -q $(call dep_commit,$(1)); then \
 			git remote set-url origin $(call dep_repo,$(1)) && \
-			git fetch && \
+			git fetch && git pull && \
 			git checkout -q $(call dep_commit,$(1)); \
 		fi; \
 	else \
@@ -701,8 +703,6 @@ define __fetch_git
 	fi; \
 	git clone -q --branch --single-branch $(call dep_commit,$(1)) -- $(join $(CACHE_DIR)/gits/,$(call dep_name,$(1))) $(2)
 endef
-
-ifeq ($(CACHE_DEPS),1)
 
 define dep_fetch_git
 	$(call __fetch_git,$(1),$(DEPS_DIR)/$(call dep_name,$(1)));

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -24,8 +24,10 @@ export REBAR_DEPS_DIR
 REBAR_GIT ?= https://github.com/rebar/rebar
 REBAR_COMMIT ?= 576e12171ab8d69b048b827b92aa65d067deea01
 
-CACHE_DIR ?= $(HOME)/.cache/erlang.mk
 CACHE_DEPS ?= 0
+
+CACHE_DIR ?= $(if $(XDG_CACHE_HOME),$(XDG_CACHE_HOME),$(HOME)/.cache)/erlang.mk
+export CACHE_DIR
 
 # External "early" plugins (see core/plugins.mk for regular plugins).
 # They both use the core_dep_plugin macro.
@@ -861,6 +863,16 @@ distclean:: distclean-deps
 
 distclean-deps:
 	$(gen_verbose) rm -rf $(DEPS_DIR)
+endif
+
+ifeq ($(CACHE_DEPS),1)
+cacheclean:: cacheclean-git cacheclean-hex
+
+cacheclean-git:
+	$(gen_verbose) rm -rf $(CACHE_DIR)/git
+
+cacheclean-hex:
+	$(gen_verbose) rm -rf $(CACHE_DIR)/hex
 endif
 
 # Forward-declare variables used in core/deps-tools.mk. This is required

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -695,8 +695,8 @@ define __fetch_git
 		cd $(join $(CACHE_DIR)/gits/,$(call dep_name,$(1))); \
 		if ! git checkout -q $(call dep_commit,$(1)); then \
 			git remote set-url origin $(call dep_repo,$(1)) && \
-			git fetch && git pull && \
-			git checkout -q $(call dep_commit,$(1)); \
+			git pull --all && \
+			git cat-file -e $(call dep_commit,$(1)) 2>/dev/null; \
 		fi; \
 	else \
 		git clone -q -n -- $(call dep_repo,$(1)) $(join $(CACHE_DIR)/gits/,$(call dep_name,$(1))); \

--- a/core/deps.mk
+++ b/core/deps.mk
@@ -703,7 +703,7 @@ define __fetch_git
 	else \
 		git clone -q -n -- $(call dep_repo,$(1)) $(join $(CACHE_DIR)/gits/,$(call dep_name,$(1))); \
 	fi; \
-	git clone -q --branch --single-branch $(call dep_commit,$(1)) -- $(join $(CACHE_DIR)/gits/,$(call dep_name,$(1))) $(2)
+	git clone -q --branch $(call dep_commit,$(1)) --single-branch -- $(join $(CACHE_DIR)/gits/,$(call dep_name,$(1))) $(2)
 endef
 
 define dep_fetch_git

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,6 +13,8 @@ endif
 # Temporary application name, taken from rule name.
 
 APP = test_$(subst -,_,$@)
+CACHE_DIR = $(CURDIR)/$(APP).cache
+export CACHE_DIR
 
 # Erlang, quickly!
 
@@ -126,7 +128,7 @@ endef
 all:: core
 
 clean::
-	$t rm -rf erl_crash.dump packages/ $(filter-out test_rebar_git/,$(wildcard test_*/))
+	$t rm -rf erl_crash.dump packages/ $(filter-out test_rebar_git/,$(wildcard test_*/)) $(CACHE_DIR)
 
 init: clean
 	$i "Prefetch Rebar if necessary"


### PR DESCRIPTION
- Enabled via `CACHE_DEPS=1`
- Cached files are beneath `$(HOME)/.cache/erlang.mk/` by default
- Will cache Git Fetches (including submodules) & Hex fetches
  - These cache in `$(CACHE_DIR)/git` & `$(CACHE_DIR)/hex`