### PR TITLE
Make parent directory of ESCRIPT_ZIP_FILE

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -4,7 +4,7 @@ ERLANG_MK_BUILD_CONFIG ?= build.config
 ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
 erlang.mk: bootstrap
-	git clone --depth 1 https://github.com/ninenines/erlang.mk $(ERLANG_MK_BUILD_DIR)
+	git clone --depth 1 https://github.com/2600hz/erlang.mk $(ERLANG_MK_BUILD_DIR)
 	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR); fi
 	cd $(ERLANG_MK_BUILD_DIR) && $(MAKE)
 	cp $(ERLANG_MK_BUILD_DIR)/erlang.mk ./erlang.mk

--- a/plugins/escript.mk
+++ b/plugins/escript.mk
@@ -29,7 +29,7 @@ help::
 
 escript-zip:: FULL=1
 escript-zip:: deps app
-	$(verbose) mkdir -p $(dir $(ESCRIPT_ZIP))
+	$(verbose) mkdir -p $(dir $(ESCRIPT_ZIP_FILE))
 	$(verbose) rm -f $(ESCRIPT_ZIP_FILE)
 	$(gen_verbose) cd .. && $(ESCRIPT_ZIP) $(ESCRIPT_ZIP_FILE) $(PROJECT)/ebin/*
 ifneq ($(DEPS),)


### PR DESCRIPTION
ESCRIPT_ZIP is the executable, should ensure the parent directory of ESCRIPT_SIP_FILE exists first.