### PR TITLE
Make parent directory of ESCRIPT_ZIP_FILE

### DIFF
--- a/plugins/escript.mk
+++ b/plugins/escript.mk
@@ -29,7 +29,7 @@ help::
 
 escript-zip:: FULL=1
 escript-zip:: deps app
-	$(verbose) mkdir -p $(dir $(ESCRIPT_ZIP))
+	$(verbose) mkdir -p $(dir $(ESCRIPT_ZIP_FILE))
 	$(verbose) rm -f $(ESCRIPT_ZIP_FILE)
 	$(gen_verbose) cd .. && $(ESCRIPT_ZIP) $(ESCRIPT_ZIP_FILE) $(PROJECT)/ebin/*
 ifneq ($(DEPS),)


### PR DESCRIPTION
ESCRIPT_ZIP is the executable, should ensure the parent directory of ESCRIPT_SIP_FILE exists first.