### PR TITLE
Verbosify autopatch targets

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -839,7 +839,7 @@ endif
 .PHONY: autopatch-$(call dep_name,$1)
 
 autopatch-$(call dep_name,$1)::
-	if [ "$1" = "elixir" -a "$(ELIXIR_PATCH)" ]; then \
+	$(verbose) if [ "$1" = "elixir" -a "$(ELIXIR_PATCH)" ]; then \
 		ln -s lib/elixir/ebin $(DEPS_DIR)/elixir/; \
 	else \
 		$$(call dep_autopatch,$(call dep_name,$1)) \

--- a/erlang.mk
+++ b/erlang.mk
@@ -4,7 +4,7 @@ ERLANG_MK_BUILD_CONFIG ?= build.config
 ERLANG_MK_BUILD_DIR ?= .erlang.mk.build
 
 erlang.mk: bootstrap
-	git clone --depth 1 https://github.com/ninenines/erlang.mk $(ERLANG_MK_BUILD_DIR)
+	git clone --depth 1 https://github.com/2600hz/erlang.mk $(ERLANG_MK_BUILD_DIR)
 	if [ -f $(ERLANG_MK_BUILD_CONFIG) ]; then cp $(ERLANG_MK_BUILD_CONFIG) $(ERLANG_MK_BUILD_DIR); fi
 	cd $(ERLANG_MK_BUILD_DIR) && $(MAKE)
 	cp $(ERLANG_MK_BUILD_DIR)/erlang.mk ./erlang.mk

--- a/plugins/escript.mk
+++ b/plugins/escript.mk
@@ -29,7 +29,7 @@ help::
 
 escript-zip:: FULL=1
 escript-zip:: deps app
-	$(verbose) mkdir -p $(dir $(ESCRIPT_ZIP))
+	$(verbose) mkdir -p $(dir $(ESCRIPT_ZIP_FILE))
 	$(verbose) rm -f $(ESCRIPT_ZIP_FILE)
 	$(gen_verbose) cd .. && $(ESCRIPT_ZIP) $(ESCRIPT_ZIP_FILE) $(PROJECT)/ebin/*
 ifneq ($(DEPS),)


### PR DESCRIPTION
Wrap the shell commands of autopatch targets in `$(verbose)` to eliminate noisy terminal output.