### PR TITLE
fix: use REL_DEPS instead of BUILD_DEPS in plugins/bootstrap.mk

### DIFF
--- a/plugins/bootstrap.mk
+++ b/plugins/bootstrap.mk
@@ -451,7 +451,7 @@ endif
 	$(verbose) mkdir config/
 	$(verbose) $(call core_render,bs_sys_config,config/sys.config)
 	$(verbose) $(call core_render,bs_vm_args,config/vm.args)
-	$(verbose) awk '/^include erlang.mk/ && !ins {print "BUILD_DEPS += relx";ins=1};{print}' Makefile > Makefile.bak
+	$(verbose) awk '/^include erlang.mk/ && !ins {print "REL_DEPS += relx";ins=1};{print}' Makefile > Makefile.bak
 	$(verbose) mv Makefile.bak Makefile
 
 new-app:


### PR DESCRIPTION
fix: https://github.com/ninenines/erlang.mk/issues/1000
use `REL_DEPS` instead of `BUILD_DEPS` in plugins/bootstrap.mk