### PR TITLE
Improve rebar.config generation

### DIFF
--- a/core/compat.mk
+++ b/core/compat.mk
@@ -3,6 +3,8 @@
 
 .PHONY: rebar.config
 
+compat_ref = {$(shell (git -C $(DEPS_DIR)/$1 show-ref -q --verify "refs/heads/$2" && echo branch) || (git -C $(DEPS_DIR)/$1 show-ref -q --verify "refs/tags/$2" && echo tag) || echo ref),"$2"}
+
 # We strip out -Werror because we don't want to fail due to
 # warnings when used as a dependency.
 
@@ -23,10 +25,10 @@ define compat_rebar_config
 $(call comma_list,$(foreach d,$(DEPS),\
 	$(if $(filter hex,$(call dep_fetch,$d)),\
 		{$(call dep_name,$d)$(comma)"$(call dep_repo,$d)"},\
-		{$(call dep_name,$d)$(comma)".*"$(comma){git,"$(call dep_repo,$d)"$(comma)"$(call dep_commit,$d)"}})))
+		{$(call dep_name,$d)$(comma)".*"$(comma){git,"$(call dep_repo,$d)"$(comma)$(call compat_ref,$(call dep_name,$d),$(call dep_commit,$d))}})))
 ]}.
 {erl_opts, $(call compat_erlc_opts_to_list,$(ERLC_OPTS))}.
 endef
 
-rebar.config:
+rebar.config: deps
 	$(gen_verbose) $(call core_render,compat_rebar_config,rebar.config)

--- a/index/cowboy.mk
+++ b/index/cowboy.mk
@@ -4,4 +4,4 @@ pkg_cowboy_description = Small, fast and modular HTTP server.
 pkg_cowboy_homepage = http://ninenines.eu
 pkg_cowboy_fetch = git
 pkg_cowboy_repo = https://github.com/ninenines/cowboy
-pkg_cowboy_commit = 1.0.4
+pkg_cowboy_commit = master

--- a/test/core_compat.mk
+++ b/test/core_compat.mk
@@ -91,7 +91,71 @@ core-compat-rebar: init
 	$i "Use rebar3 to build the application"
 	$t cd $(APP) && ./rebar3 compile $v
 
-core-compat-rebar-deps-git: init
+core-compat-rebar-deps-git-branch: init
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Add Cowboy as a dependency"
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = cowboy\ndep_cowboy = git https://github.com/ninenines/cowboy master\n"}' $(APP)/Makefile
+
+	$i "Run 'make rebar.config'"
+	$t $(MAKE) -C $(APP) rebar.config $v
+
+	$i "Check that rebar.config was created"
+	$t test -f $(APP)/rebar.config
+
+	$i "Check that Cowboy is listed in rebar.config with a branch"
+	$t $(ERL) -eval " \
+		{ok, C} = file:consult(\"$(APP)/rebar.config\"), \
+		{_, [{cowboy, _, {git, _, {branch, \"master\"}}}]} = lists:keyfind(deps, 1, C), \
+		halt()"
+
+	$i "Distclean the application"
+	$t $(MAKE) -C $(APP) distclean $v
+
+	$i "Download rebar3"
+	$t curl --retry 5 -s -L -o $(APP)/rebar3 $(REBAR3_BINARY)
+	$t chmod +x $(APP)/rebar3
+
+	$i "Use rebar3 to build the application"
+	$t cd $(APP) && ./rebar3 compile $v
+
+core-compat-rebar-deps-git-ref: init
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Add Cowboy as a dependency"
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = cowboy\ndep_cowboy = git https://github.com/ninenines/cowboy 7e160b49\n"}' $(APP)/Makefile
+
+	$i "Run 'make rebar.config'"
+	$t $(MAKE) -C $(APP) rebar.config $v
+
+	$i "Check that rebar.config was created"
+	$t test -f $(APP)/rebar.config
+
+	$i "Check that Cowboy is listed in rebar.config with a branch"
+	$t $(ERL) -eval " \
+		{ok, C} = file:consult(\"$(APP)/rebar.config\"), \
+		{_, [{cowboy, _, {git, _, {ref, \"7e160b49\"}}}]} = lists:keyfind(deps, 1, C), \
+		halt()"
+
+	$i "Distclean the application"
+	$t $(MAKE) -C $(APP) distclean $v
+
+	$i "Download rebar3"
+	$t curl --retry 5 -s -L -o $(APP)/rebar3 $(REBAR3_BINARY)
+	$t chmod +x $(APP)/rebar3
+
+	$i "Use rebar3 to build the application"
+	$t cd $(APP) && ./rebar3 compile $v
+
+core-compat-rebar-deps-git-tag: init
 
 	$i "Bootstrap a new OTP library named $(APP)"
 	$t mkdir $(APP)/
@@ -107,10 +171,10 @@ core-compat-rebar-deps-git: init
 	$i "Check that rebar.config was created"
 	$t test -f $(APP)/rebar.config
 
-	$i "Check that Cowboy is listed in rebar.config"
+	$i "Check that Cowboy is listed in rebar.config with a tag"
 	$t $(ERL) -eval " \
 		{ok, C} = file:consult(\"$(APP)/rebar.config\"), \
-		{_, [{cowboy, _, {git, _, \"2.9.0\"}}]} = lists:keyfind(deps, 1, C), \
+		{_, [{cowboy, _, {git, _, {tag, \"2.9.0\"}}}]} = lists:keyfind(deps, 1, C), \
 		halt()"
 
 	$i "Distclean the application"
@@ -174,7 +238,7 @@ core-compat-rebar-deps-pkg: init
 	$i "Check that Cowboy is listed in rebar.config"
 	$t $(ERL) -eval " \
 		{ok, C} = file:consult(\"$(APP)/rebar.config\"), \
-		{_, [{cowboy, _, {git, \"https://github.com/\" ++ _, _}}]} = lists:keyfind(deps, 1, C), \
+		{_, [{cowboy, _, {git, \"https://github.com/\" ++ _, {branch, _}}}]} = lists:keyfind(deps, 1, C), \
 		halt()"
 
 	$i "Distclean the application"

--- a/test/core_deps.mk
+++ b/test/core_deps.mk
@@ -1281,8 +1281,8 @@ core-deps-order-first: init
 	$t cp ../erlang.mk $(APP)/my_dep/
 	$t $(MAKE) -C $(APP)/my_dep/ -f erlang.mk bootstrap-lib $v
 
-	$i "Add Cowlib 1.0.0 to the list of dependencies for my_dep"
-	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = cowlib\ndep_cowlib = git https://github.com/ninenines/cowlib 1.0.0\n"}' $(APP)/my_dep/Makefile
+	$i "Add Cowlib 2.0.0 to the list of dependencies for my_dep"
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = cowlib\ndep_cowlib = git https://github.com/ninenines/cowlib 2.0.0\n"}' $(APP)/my_dep/Makefile
 
 ifdef LEGACY
 	$i "Add Cowboy and my_dep to the applications key in the .app.src file"
@@ -1303,7 +1303,7 @@ endif
 		[ok = application:load(App) || App <- [$(APP), cowboy, cowlib, my_dep, ranch]], \
 		{ok, Deps} = application:get_key($(APP), applications), \
 		true = lists:member(cowboy, Deps), \
-		{ok, \"1.0.0\"} = application:get_key(cowlib, vsn), \
+		{ok, \"2.0.0\"} = application:get_key(cowlib, vsn), \
 		halt()"
 
 # A higher-level dependency always wins.
@@ -1314,8 +1314,8 @@ core-deps-order-top: init
 	$t cp ../erlang.mk $(APP)/
 	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
 
-	$i "Add Cowboy package and Cowlib 1.0.0 to the list of dependencies"
-	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = cowboy cowlib\ndep_cowlib = git https://github.com/ninenines/cowlib 1.0.0\n"}' $(APP)/Makefile
+	$i "Add Cowboy package and Cowlib 2.0.0 to the list of dependencies"
+	$t perl -ni.bak -e 'print;if ($$.==1) {print "DEPS = cowboy cowlib\ndep_cowlib = git https://github.com/ninenines/cowlib 2.0.0\n"}' $(APP)/Makefile
 
 ifdef LEGACY
 	$i "Add Cowboy to the applications key in the .app.src file"
@@ -1335,7 +1335,7 @@ endif
 		[ok = application:load(App) || App <- [$(APP), cowboy, cowlib, ranch]], \
 		{ok, Deps} = application:get_key($(APP), applications), \
 		true = lists:member(cowboy, Deps), \
-		{ok, \"1.0.0\"} = application:get_key(cowlib, vsn), \
+		{ok, \"2.0.0\"} = application:get_key(cowlib, vsn), \
 		halt()"
 
 ifndef LEGACY


### PR DESCRIPTION
We now provide the version as a tagged tuple indicating whether this is a branch, tag or ref. This should help rebar automatically upgrade dependencies, and remove an annoying warning when rebar is used.

In order to detect the type of version the dependencies must be available, therefore the rebar.config target now depends on the deps target.

To test this the Cowboy package version had to be changed from 1.0.4 to master. This is a breaking change, but I do not expect too many people to still use 1.0.4.

#900