### PR TITLE
Native Elixir Fixes

### DIFF
--- a/core/elixir.mk
+++ b/core/elixir.mk
@@ -35,7 +35,7 @@ define dep_autopatch_mix.erl
 	Application = try Mod:application() catch error:undef -> [] end,
 	StartMod = case lists:keyfind(mod, 1, Application) of
 		{mod, {StartMod0, _StartArgs}} ->
-			StartMod0;
+			atom_to_list(StartMod0);
 		_ ->
 			""
 	end,

--- a/core/elixir.mk
+++ b/core/elixir.mk
@@ -25,7 +25,11 @@ define dep_autopatch_mix.erl
 	{ok, _} = application:ensure_all_started(elixir),
 	{ok, _} = application:ensure_all_started(mix),
 	MixFile = <<"$(call core_native_path,$(DEPS_DIR)/$1/mix.exs)">>,
-	[{Mod, Bin}] = elixir_compiler:file(MixFile, fun(_File, _LexerPid) -> ok end),
+	{Mod, Bin} =
+		case elixir_compiler:file(MixFile, fun(_File, _LexerPid) -> ok end) of
+			[{T = {_, _}, _CheckerPid}] -> T
+			[T = {_, _}] -> T;
+		end,
 	{module, Mod} = code:load_binary(Mod, binary_to_list(MixFile), Bin),
 	Project = Mod:project(),
 	Application = try Mod:application() catch error:undef -> [] end,

--- a/core/elixir.mk
+++ b/core/elixir.mk
@@ -143,12 +143,15 @@ define compile_ex.erl
 	ModCode = list_to_atom("Elixir.Code"),
 	ModCode:put_compiler_option(ignore_module_conflict, true),
 	ModComp = list_to_atom("Elixir.Kernel.ParallelCompiler"),
-	case ModComp:compile_to_path([$(call comma_list,$(patsubst %,<<"%">>,$(EX_FILES)))], <<"ebin/">>) of
-		{ok, Modules, _} ->
-			halt(0);
-		{error, [], _WarnedModules} ->
-			halt(0);
-		{error, _ErroredModules, _WarnedModules} ->
-			halt(1)
-	end
+	ModMixProject = list_to_atom("Elixir.Mix.Project"),
+	ModMixProject:in_project($(PROJECT), ".", [], fun(_MixFile) ->
+		case ModComp:compile_to_path([$(call comma_list,$(patsubst %,<<"%">>,$(EX_FILES)))], <<"ebin/">>) of
+			{ok, Modules, _} ->
+				halt(0);
+			{error, [], _WarnedModules} ->
+				halt(0);
+			{error, _ErroredModules, _WarnedModules} ->
+				halt(1)
+		end
+	end)
 endef

--- a/core/elixir.mk
+++ b/core/elixir.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, Tyler Hughes <artman41@gmail.com>
+# Copyright (c) 2024, Tyler Hughes <tyler@tylerhughes.dev>
 # Copyright (c) 2024, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 

--- a/core/elixir.mk
+++ b/core/elixir.mk
@@ -16,7 +16,7 @@ else
 ERL_LIBS := $(ERL_LIBS):$(DEPS_DIR)/elixir/lib/
 endif
 
-elixirc_verbose_0 = @echo " EXC    $(words $(EX_FILES)) files"
+elixirc_verbose_0 = @echo " EXC    $(words $(EX_FILES)) files";
 elixirc_verbose_2 = set -x;
 elixirc_verbose = $(elixirc_verbose_$(V))
 
@@ -139,7 +139,12 @@ define compile_ex.erl
 	ModCode = list_to_atom("Elixir.Code"),
 	ModCode:put_compiler_option(ignore_module_conflict, true),
 	ModComp = list_to_atom("Elixir.Kernel.ParallelCompiler"),
-	{ok, Modules, _} = ModComp:compile_to_path([$(call comma_list,$(patsubst %,<<"%">>,$(EX_FILES)))], <<"ebin/">>),
-	lists:foreach(fun(E) -> io:format("~p ", [E]) end, Modules),
-	halt()
+	case ModComp:compile_to_path([$(call comma_list,$(patsubst %,<<"%">>,$(EX_FILES)))], <<"ebin/">>) of
+		{ok, Modules, _} ->
+			halt(0);
+		{error, [], _WarnedModules} ->
+			halt(0);
+		{error, _ErroredModules, _WarnedModules} ->
+			halt(1)
+	end
 endef

--- a/core/elixir.mk
+++ b/core/elixir.mk
@@ -155,3 +155,24 @@ define compile_ex.erl
 		end
 	end)
 endef
+
+define get_ex_modules.erl
+	ModCode = list_to_atom("Elixir.Code"),
+	AtomAliases = list_to_atom("__aliases__"),
+	lists:foreach(
+		fun(Path) ->
+			{ok, Bin} = file:read_file(Path),
+			{ok, {_, _, AST}} = ModCode:string_to_quoted(Bin),
+			case lists:keyfind(AtomAliases, 1, AST) of
+				false -> ok;
+				{AtomAliases, _, Aliases} ->
+					case [[".", atom_to_list(A)] || A <- Aliases] of
+						[] -> ok;
+						Joined ->
+							Mod = list_to_atom(lists:flatten(["Elixir", Joined])),
+							io:format("~p ", [Mod])
+					end
+			end
+		end, [$(call comma_list,$(patsubst %,<<"%">>,$(EX_FILES)))]),
+	halt(0)
+endef

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -306,11 +306,11 @@ endef
 ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.src) $(EX_FILES)
 	$(eval FILES_TO_COMPILE := $(filter-out $(EX_FILES) src/$(PROJECT).app.src,$?))
 	$(if $(strip $(FILES_TO_COMPILE)),$(call compile_erl,$(FILES_TO_COMPILE)))
-	$(if $(filter $?,$(EX_FILES)),$(elixirc_verbose) $(eval MODULES := $(shell $(call erlang,$(call compile_ex.erl,$(EX_FILES))))))
+	$(if $(filter $?,$(EX_FILES)),$(elixirc_verbose) $(call erlang,$(call compile_ex.erl,$(EX_FILES))))
 # Older git versions do not have the --first-parent flag. Do without in that case.
 	$(eval GITDESCRIBE := $(shell git describe --dirty --abbrev=7 --tags --always --first-parent 2>/dev/null \
 		|| git describe --dirty --abbrev=7 --tags --always 2>/dev/null || true))
-	$(eval MODULES := $(MODULES) $(patsubst %,'%',$(sort $(notdir $(basename \
+	$(eval MODULES := $(MODULES) $(notdir $(basename $(wildcard ebin/Elixir.*))) $(patsubst %,'%',$(sort $(notdir $(basename \
 		$(filter-out $(ERLC_EXCLUDE_PATHS),$(ERL_FILES) $(CORE_FILES) $(BEAM_FILES)))))))
 ifeq ($(wildcard src/$(PROJECT).app.src),)
 	$(app_verbose) printf '$(subst %,%%,$(subst $(newline),\n,$(subst ','\'',$(call app_file,$(GITDESCRIBE),$(MODULES)))))' \

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -310,7 +310,7 @@ ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.s
 # Older git versions do not have the --first-parent flag. Do without in that case.
 	$(eval GITDESCRIBE := $(shell git describe --dirty --abbrev=7 --tags --always --first-parent 2>/dev/null \
 		|| git describe --dirty --abbrev=7 --tags --always 2>/dev/null || true))
-	$(eval MODULES := $(MODULES) $(notdir $(basename $(wildcard ebin/Elixir.*))) $(patsubst %,'%',$(sort $(notdir $(basename \
+	$(eval MODULES := $(MODULES) $(shell $(call erlang,$(call get_ex_modules.erl))) $(patsubst %,'%',$(sort $(notdir $(basename \
 		$(filter-out $(ERLC_EXCLUDE_PATHS),$(ERL_FILES) $(CORE_FILES) $(BEAM_FILES)))))))
 ifeq ($(wildcard src/$(PROJECT).app.src),)
 	$(app_verbose) printf '$(subst %,%%,$(subst $(newline),\n,$(subst ','\'',$(call app_file,$(GITDESCRIBE),$(MODULES)))))' \

--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -306,13 +306,15 @@ endef
 ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.src) $(EX_FILES)
 	$(eval FILES_TO_COMPILE := $(filter-out $(EX_FILES) src/$(PROJECT).app.src,$?))
 	$(if $(strip $(FILES_TO_COMPILE)),$(call compile_erl,$(FILES_TO_COMPILE)))
-	$(if $(filter $?,$(EX_FILES)),$(elixirc_verbose) $(call erlang,$(call compile_ex.erl,$(EX_FILES))))
+	$(if $(filter $?,$(EX_FILES)),$(elixirc_verbose) $(eval MODULES := $(shell $(call erlang,$(call compile_ex.erl)))))
+	$(eval ELIXIR_COMP_FAILED := $(if $(filter _ERROR_,$(firstword $(MODULES))),true,false))
 # Older git versions do not have the --first-parent flag. Do without in that case.
 	$(eval GITDESCRIBE := $(shell git describe --dirty --abbrev=7 --tags --always --first-parent 2>/dev/null \
 		|| git describe --dirty --abbrev=7 --tags --always 2>/dev/null || true))
-	$(eval MODULES := $(MODULES) $(shell $(call erlang,$(call get_ex_modules.erl))) $(patsubst %,'%',$(sort $(notdir $(basename \
+	$(eval MODULES := $(MODULES) $(patsubst %,'%',$(sort $(notdir $(basename \
 		$(filter-out $(ERLC_EXCLUDE_PATHS),$(ERL_FILES) $(CORE_FILES) $(BEAM_FILES)))))))
 ifeq ($(wildcard src/$(PROJECT).app.src),)
+	$(verbose) if $(ELIXIR_COMP_FAILED); then exit 1; fi;
 	$(app_verbose) printf '$(subst %,%%,$(subst $(newline),\n,$(subst ','\'',$(call app_file,$(GITDESCRIBE),$(MODULES)))))' \
 		> ebin/$(PROJECT).app
 	$(verbose) if ! $(call erlang,$(call validate_app_file)); then \


### PR DESCRIPTION
* **Cause failed compilation of .ex files to prevent creation of .app file**
    * **Replace wildcard for ex beams for a shell command** 
    * _To prevent failed `.ex` compilation from continuing to create a `$(PROJECT).app` file, I've moved the elixir generation code to be ran by the actual shell. Doing this though meant the Module names of the compiled `.ex` files needed to be found separately. To solve this, I've tried to use a shell command to manually build the Module name based on the `__aliases__` attribute in the elixir ast of the code_
* **Allow support for Elixir v1.13 (supported by OTP 23)**
     * _I'm happy to remove this commit from the branch if you don't want to support OTP 23 essen_
* **Replace my email**
* **Account for .ex files which reference mix.exs config**
    * _I noticed when using the dependency `mint` that it referenced the `Mix.Project.config()` at compile time, hence the need to load the `mix.exs` project during `.ex` compilation_
* **Simplify Ex compilation failure**
    * _As suggested, modified the `compile_ex.erl` to return the compiled modules for easier var binding. The erl code will now redirect the errors printed by `'Elixir.Kernel.ParallelCompiler':compile_to_path/2` to `stderr` & print to `stdout` only for the module names or the word `_ERROR_` on a failed compilation_