### PR TITLE
Add support for specifying Hex requirements for dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
       uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ matrix.erlang }}
-        elixir-version: 1.17
+        elixir-version: 1.18
         version-type: loose
 
     - name: Setup MSYS2 (Windows)

--- a/plugins/hex.mk
+++ b/plugins/hex.mk
@@ -91,7 +91,7 @@ define hex_tarball_create.erl
 			<<"$(if $(subst hex,,$(call query_fetch_method,$d)),$d,$(if $(word 3,$(dep_$d)),$(word 3,$(dep_$d)),$d))">> => #{
 				<<"app">> => <<"$d">>,
 				<<"optional">> => false,
-				<<"requirement">> => <<"$(call query_version,$d)">>
+				<<"requirement">> => <<"$(if $(hex_req_$d),$(strip $(hex_req_$d)),$(call query_version,$d))">>
 			},)
 		$(if $(DEPS),dummy => dummy)
 	},


### PR DESCRIPTION
This allows overriding the default which is to use the same explicit version as the dep_* line, and instead specify ranges of versions.