### PR TITLE
Refine postprocessing of project name for use in man pages

### DIFF
--- a/plugins/asciidoc.mk
+++ b/plugins/asciidoc.mk
@@ -40,7 +40,7 @@ else
 
 MAN_INSTALL_PATH ?= /usr/local/share/man
 MAN_SECTIONS ?= 3 7
-MAN_PROJECT ?= $(shell echo $(PROJECT) | sed 's/^./\U&\E/')
+MAN_PROJECT ?= $(shell echo $(PROJECT) | awk '{ print toupper(substr($$0,1,1)) substr($$0,2) }')
 MAN_VERSION ?= $(PROJECT_VERSION)
 
 # Plugin-specific targets.


### PR DESCRIPTION
Hi there, it's really nice that generation of man pages is possible (`make install-docs`).

When viewing them for Cowboy, I noticed that the project name is messed up:

<img width="752" alt="Screenshot 2025-04-27 at 12 35 37" src="https://github.com/user-attachments/assets/81248fb0-4165-41de-94da-0faa35e01223" />

That seems to be because a non-portable `sed` feature is used to capitalise the first letter. I've replaced that with a call to `awk` that [should be portable.](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html)