### PR TITLE
GitHub Actions: Switch to `cross-platform-actions` to run tests in VMs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -377,7 +377,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vm:
+        os:
           - freebsd
         suite:
           - core-app
@@ -424,18 +424,17 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run tests (FreeBSD)
-      if: matrix.vm == 'freebsd'
-      uses: vmactions/freebsd-vm@v1
+      uses: cross-platform-actions/action@v0.29.0
       timeout-minutes: 60
       with:
-        usesh: true
-        copyback: false
-        prepare: |
-          pkg update
-          pkg upgrade -y
-          pkg install -y erlang elixir bash ca_root_nss gmake git libsodium perl5 7-zip
+        operating_system: ${{ matrix.os }}
+        version: '14.3'
+        run: |
+          sudo pkg update
+          sudo pkg upgrade -y
+          sudo pkg install -y erlang elixir bash ca_root_nss gmake git libsodium perl5 7-zip
+
           git config --global safe.directory '*'
           erl -sname init_cookie -run erlang halt
 
-        run: |
-          gmake check c=${{ matrix.suite }} -j4
+          gmake check c=${{ matrix.suite }} -j4 USE_NODETOOL=1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -426,6 +426,7 @@ jobs:
     - name: Run tests (FreeBSD)
       if: matrix.vm == 'freebsd'
       uses: vmactions/freebsd-vm@v1
+      timeout-minutes: 60
       with:
         usesh: true
         copyback: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -438,3 +438,11 @@ jobs:
           erl -sname init_cookie -run erlang halt
 
           gmake check c=${{ matrix.suite }} -j4 USE_NODETOOL=1
+
+    - name: Upload artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.os }} ${{ matrix.suite }}
+        path: |
+          test/test_*/


### PR DESCRIPTION
`vmactions` VM fails to boot quite frequently and we have no visibility on the reason of the failure.

The only failure I got out-of-the-box with cross-platform-actions VM was the `core-deps-rel` test case which hangs. It comes from the use of `erl_call` to detect if the Erlang node was started correctly. A comment in the generated release starts scripts says:

    # users who depend on stdout when running rpc calls must still use nodetool
    # so we have an overload option to force use of nodetool instead of erl_call

If `$USE_NODETOOL` is set, it will use `relx_nodetool` instead. Indeed, this fixed the hang.

While here, set a timeout of one hour in case a VM even hangs again. Much more acceptable than the default 6 hours.

Also, in case of a test failure, upload the artifacts like it is already the case for Linux-based tests.