### PR TITLE
BugFix: Keep Elixir modules listed in ebin/PROJECT.app on erl-only rebuilds

### DIFF
--- a/core/erlc.mk
+++ b/core/erlc.mk
@@ -308,10 +308,30 @@ define validate_app_file
 	end
 endef
 
-ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.src) $(EX_FILES)
+EX_MODULES_CACHE = $(ERLANG_MK_TMP)/ex_modules.log
+
+ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.src) $(EX_FILES) | $(ERLANG_MK_TMP)
 	$(eval FILES_TO_COMPILE := $(filter-out $(EX_FILES) src/$(PROJECT).app.src,$?))
 	$(if $(strip $(FILES_TO_COMPILE)),$(call compile_erl,$(FILES_TO_COMPILE)))
-	$(if $(filter $(ELIXIR),disable),,$(if $(filter $?,$(EX_FILES)),$(elixirc_verbose) $(eval MODULES := $(shell $(call erlang,$(call compile_ex.erl,$(EX_FILES)))))))
+# MODULES must include the Elixir-defined modules, or they get silently
+# dropped from the generated .app file's modules entry. We only know a
+# module's real name by compiling it (an .ex file's name need not match
+# the module(s) it defines), so we cache the resolved list to
+# EX_MODULES_CACHE and only recompile when we have to: an EX_FILE is
+# itself out of date, or the cache doesn't exist yet (first build, or
+# after a `distclean`). Any other rebuild (e.g. triggered solely by an
+# out-of-date .erl or app.src) reuses the cache instead of recompiling
+# every Elixir file all over again.
+ifneq ($(ELIXIR),disable)
+ifneq ($(strip $(EX_FILES)),)
+	$(eval EX_FILES_CHANGED := $(filter $?,$(EX_FILES)))
+	$(eval EX_CACHE_MISSING := $(if $(wildcard $(EX_MODULES_CACHE)),,1))
+	$(if $(or $(EX_FILES_CHANGED),$(EX_CACHE_MISSING)),\
+		$(elixirc_verbose) $(eval MODULES := $(shell $(call erlang,$(call compile_ex.erl,$(EX_FILES))))) \
+		$(if $(filter _ERROR_,$(firstword $(MODULES))),,$(file >$(EX_MODULES_CACHE),$(MODULES))),\
+		$(eval MODULES := $(shell cat $(EX_MODULES_CACHE))))
+endif
+endif
 	$(eval ELIXIR_COMP_FAILED := $(if $(filter _ERROR_,$(firstword $(MODULES))),true,false))
 # Older git versions do not have the --first-parent flag. Do without in that case.
 	$(verbose) if $(ELIXIR_COMP_FAILED); then exit 1; fi

--- a/test/core_elixir.mk
+++ b/test/core_elixir.mk
@@ -69,6 +69,59 @@ core-elixir-compile-from-src: init
 		[{module, M} = code:load_file(M) || M <- Mods], \
 		halt()"
 
+core-elixir-keep-modules-on-erl-only-rebuild: init
+
+	$i "Bootstrap a new OTP library named $(APP)"
+	$t mkdir $(APP)/
+	$t cp ../erlang.mk $(APP)/
+	$t $(MAKE) -C $(APP) -f erlang.mk bootstrap-lib $v
+
+	$i "Create Elixir source file hello.ex"
+	$t mkdir $(APP)/lib
+	$t printf "%s\n" \
+		"defmodule HelloWorld do" \
+		"  def hello do" \
+		'	IO.puts("Hello, world!")' \
+		"  end" \
+		"end" > $(APP)/lib/hello.ex
+
+	$i "Build the application"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that the Elixir module is listed in the .app file"
+	$t grep -q "'Elixir.HelloWorld'" $(APP)/ebin/$(APP).app
+
+	$i "Place a marker file to detect what the next build touches"
+	$t touch $(APP)/marker
+
+	$i "Wait to ensure the new file has a later modification time"
+	$t $(SLEEP)
+
+	$i "Add an unrelated Erlang source file"
+	$t printf "%s\n" \
+		"-module(unrelated)." \
+		"-export([go/0])." \
+		"go() -> ok." > $(APP)/src/unrelated.erl
+
+	$i "Rebuild the application"
+	$t $(MAKE) -C $(APP) $v
+
+	$i "Check that the Elixir module is still listed in the .app file"
+	$t grep -q "'Elixir.HelloWorld'" $(APP)/ebin/$(APP).app
+
+	$i "Check that the Elixir module was not recompiled"
+	$t ! find $(APP) -type f -newer $(APP)/marker | grep -q Elixir.HelloWorld.beam
+	$t rm $(APP)/marker
+
+	$i "Check that both modules are known to the application and loadable"
+	$t $(ERL) -pa $(APP)/ebin/ -pa $(APP)/deps/*/ebin -pa $(dir $(shell elixir -e 'IO.puts(:code.lib_dir(:elixir))'))/*/ebin -eval " \
+		ok = application:start($(APP)), \
+		{ok, Mods} = application:get_key($(APP), modules), \
+		true = lists:member('Elixir.HelloWorld', Mods), \
+		true = lists:member(unrelated, Mods), \
+		{module, 'Elixir.HelloWorld'} = code:load_file('Elixir.HelloWorld'), \
+		halt()"
+
 core-elixir-disable: init
 
 	$i "Bootstrap a new OTP library named $(APP)"


### PR DESCRIPTION
Fixes #1052 

**To be upfront**: Claude noticed this while I was having it scaffold a project.

Claude identified and produced the fix but I've had it break the change into more simpler and clean code because having it as a one-liner was almost unreadable.

I've reviewed the code myself and both the code & test appear good.

Happy to rework the code if needed